### PR TITLE
Feature/configurable database

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "uvicorn",
     "sqlalchemy",
     "mysqlclient",
+    "python_dotenv",
 ]
 
 [project.optional-dependencies]

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,4 @@
-from __future__ import annotations
-
+import functools
 import os
 import tomllib
 import typing
@@ -10,7 +9,7 @@ from dotenv import load_dotenv
 TomlTable = dict[str, typing.Any]
 
 
-def apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTable:
+def _apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTable:
     defaults = configuration[table]["defaults"]
     return {
         subtable: defaults | overrides
@@ -19,32 +18,29 @@ def apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTab
     }
 
 
-def load_configuration(file: Path) -> TomlTable:
+@functools.cache
+def load_database_configuration(file: Path = Path(__file__).parent / "config.toml") -> TomlTable:
     configuration = tomllib.loads(file.read_text())
-    configuration["databases"] = apply_defaults_to_subtables(
+
+    database_configuration = _apply_defaults_to_subtables(
         configuration,
         table="databases",
     )
-    return configuration
-
-
-load_dotenv()
-_configuration = load_configuration(Path(__file__).parent / "config.toml")
-
-DATABASE_CONFIGURATION = _configuration["databases"]
-DATABASE_CONFIGURATION["openml"]["username"] = os.environ.get(
-    "OPENML_DATABASES_OPENML_USERNAME",
-    "root",
-)
-DATABASE_CONFIGURATION["openml"]["password"] = os.environ.get(
-    "OPENML_DATABASES_OPENML_PASSWORD",
-    "ok",
-)
-DATABASE_CONFIGURATION["expdb"]["username"] = os.environ.get(
-    "OPENML_DATABASES_EXPDB_USERNAME",
-    "root",
-)
-DATABASE_CONFIGURATION["expdb"]["password"] = os.environ.get(
-    "OPENML_DATABASES_EXPDB_PASSWORD",
-    "ok",
-)
+    load_dotenv()
+    database_configuration["openml"]["username"] = os.environ.get(
+        "OPENML_DATABASES_OPENML_USERNAME",
+        "root",
+    )
+    database_configuration["openml"]["password"] = os.environ.get(
+        "OPENML_DATABASES_OPENML_PASSWORD",
+        "ok",
+    )
+    database_configuration["expdb"]["username"] = os.environ.get(
+        "OPENML_DATABASES_EXPDB_USERNAME",
+        "root",
+    )
+    database_configuration["expdb"]["password"] = os.environ.get(
+        "OPENML_DATABASES_EXPDB_PASSWORD",
+        "ok",
+    )
+    return database_configuration

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import tomllib
+import typing
+from pathlib import Path
+
+TomlTable = dict[str, typing.Any]
+
+
+def apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTable:
+    defaults = configuration[table]["defaults"]
+    return {
+        subtable: defaults | overrides
+        for subtable, overrides in configuration[table].items()
+        if subtable != "defaults"
+    }
+
+
+def load_configuration(file: Path) -> TomlTable:
+    configuration = tomllib.loads(file.read_text())
+    configuration["databases"] = apply_defaults_to_subtables(
+        configuration,
+        table="databases",
+    )
+    return configuration
+
+
+_configuration = load_configuration(Path(__file__).parent / "config.toml")
+DATABASE_CONFIGURATION = _configuration["databases"]

--- a/src/config.py
+++ b/src/config.py
@@ -9,11 +9,11 @@ from dotenv import load_dotenv
 TomlTable = dict[str, typing.Any]
 
 
-def _apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTable:
-    defaults = configuration[table]["defaults"]
+def _apply_defaults_to_siblings(configuration: TomlTable) -> TomlTable:
+    defaults = configuration["defaults"]
     return {
-        subtable: defaults | overrides
-        for subtable, overrides in configuration[table].items()
+        subtable: (defaults | overrides) if isinstance(overrides, dict) else overrides
+        for subtable, overrides in configuration.items()
         if subtable != "defaults"
     }
 
@@ -22,9 +22,8 @@ def _apply_defaults_to_subtables(configuration: TomlTable, table: str) -> TomlTa
 def load_database_configuration(file: Path = Path(__file__).parent / "config.toml") -> TomlTable:
     configuration = tomllib.loads(file.read_text())
 
-    database_configuration = _apply_defaults_to_subtables(
-        configuration,
-        table="databases",
+    database_configuration = _apply_defaults_to_siblings(
+        configuration["databases"],
     )
     load_dotenv()
     database_configuration["openml"]["username"] = os.environ.get(

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import os
 import tomllib
 import typing
 from pathlib import Path
+
+from dotenv import load_dotenv
 
 TomlTable = dict[str, typing.Any]
 
@@ -25,5 +28,23 @@ def load_configuration(file: Path) -> TomlTable:
     return configuration
 
 
+load_dotenv()
 _configuration = load_configuration(Path(__file__).parent / "config.toml")
+
 DATABASE_CONFIGURATION = _configuration["databases"]
+DATABASE_CONFIGURATION["openml"]["username"] = os.environ.get(
+    "OPENML_DATABASES_OPENML_USERNAME",
+    "root",
+)
+DATABASE_CONFIGURATION["openml"]["password"] = os.environ.get(
+    "OPENML_DATABASES_OPENML_PASSWORD",
+    "ok",
+)
+DATABASE_CONFIGURATION["expdb"]["username"] = os.environ.get(
+    "OPENML_DATABASES_EXPDB_USERNAME",
+    "root",
+)
+DATABASE_CONFIGURATION["expdb"]["password"] = os.environ.get(
+    "OPENML_DATABASES_EXPDB_PASSWORD",
+    "ok",
+)

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,0 +1,11 @@
+[databases.defaults]
+host="127.0.0.1"
+port="3306"
+# SQLAlchemy `dialect` and `driver`: https://docs.sqlalchemy.org/en/20/dialects/index.html
+drivername="mysql"
+
+[databases.expdb]
+database="openml_expdb"
+
+[databases.openml]
+database="openml"

--- a/src/database/datasets.py
+++ b/src/database/datasets.py
@@ -1,17 +1,29 @@
 """ Translation from https://github.com/openml/OpenML/blob/c19c9b99568c0fabb001e639ff6724b9a754bbc9/openml_OS/models/api/v1/Api_data.php#L707"""
 from typing import Any
 
+from config import DATABASE_CONFIGURATION
 from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL
 
 from database.meta import get_column_names
 
+expdb_url = URL.create(
+    username="root",
+    password="ok",
+    **DATABASE_CONFIGURATION["expdb"],
+)
 expdb = create_engine(
-    "mysql://root:ok@127.0.0.1:3306/openml_expdb",
+    expdb_url,
     echo=True,
     pool_recycle=3600,
 )
+openml_url = URL.create(
+    username="root",
+    password="ok",
+    **DATABASE_CONFIGURATION["openml"],
+)
 openml = create_engine(
-    "mysql://root:ok@127.0.0.1:3306/openml",
+    openml_url,
     echo=True,
     pool_recycle=3600,
 )

--- a/src/database/datasets.py
+++ b/src/database/datasets.py
@@ -7,21 +7,13 @@ from sqlalchemy.engine import URL
 
 from database.meta import get_column_names
 
-expdb_url = URL.create(
-    username="root",
-    password="ok",
-    **DATABASE_CONFIGURATION["expdb"],
-)
+expdb_url = URL.create(**DATABASE_CONFIGURATION["expdb"])
 expdb = create_engine(
     expdb_url,
     echo=True,
     pool_recycle=3600,
 )
-openml_url = URL.create(
-    username="root",
-    password="ok",
-    **DATABASE_CONFIGURATION["openml"],
-)
+openml_url = URL.create(**DATABASE_CONFIGURATION["openml"])
 openml = create_engine(
     openml_url,
     echo=True,

--- a/src/database/datasets.py
+++ b/src/database/datasets.py
@@ -1,19 +1,20 @@
 """ Translation from https://github.com/openml/OpenML/blob/c19c9b99568c0fabb001e639ff6724b9a754bbc9/openml_OS/models/api/v1/Api_data.php#L707"""
 from typing import Any
 
-from config import DATABASE_CONFIGURATION
+from config import load_database_configuration
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL
 
 from database.meta import get_column_names
 
-expdb_url = URL.create(**DATABASE_CONFIGURATION["expdb"])
+_database_configuration = load_database_configuration()
+expdb_url = URL.create(**_database_configuration["expdb"])
 expdb = create_engine(
     expdb_url,
     echo=True,
     pool_recycle=3600,
 )
-openml_url = URL.create(**DATABASE_CONFIGURATION["openml"])
+openml_url = URL.create(**_database_configuration["openml"])
 openml = create_engine(
     openml_url,
     echo=True,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,20 +1,27 @@
 import os
 from pathlib import Path
 
-from config import _apply_defaults_to_subtables, load_database_configuration
+from config import _apply_defaults_to_siblings, load_database_configuration
 
 
-def test_apply_defaults_to_subtables_applies_defaults() -> None:
-    input_ = {"foo": {"defaults": {1: 1}, "other": {}}}
+def test_apply_defaults_to_siblings_applies_defaults() -> None:
+    input_ = {"defaults": {1: 1}, "other": {}}
     expected = {"other": {1: 1}}
-    output = _apply_defaults_to_subtables(input_, table="foo")
+    output = _apply_defaults_to_siblings(input_)
     assert expected == output
 
 
-def test_apply_defaults_to_subtables_does_not_override() -> None:
-    input_ = {"foo": {"defaults": {1: 1}, "other": {1: 2}}}
+def test_apply_defaults_to_siblings_does_not_override() -> None:
+    input_ = {"defaults": {1: 1}, "other": {1: 2}}
     expected = {"other": {1: 2}}
-    output = _apply_defaults_to_subtables(input_, table="foo")
+    output = _apply_defaults_to_siblings(input_)
+    assert expected == output
+
+
+def test_apply_defaults_to_siblings_ignores_nontables() -> None:
+    input_ = {"defaults": {1: 1}, "other": {1: 2}, "not-a-table": 3}
+    expected = {"other": {1: 2}, "not-a-table": 3}
+    output = _apply_defaults_to_siblings(input_)
     assert expected == output
 
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+from config import _apply_defaults_to_subtables, load_database_configuration
+
+
+def test_apply_defaults_to_subtables_applies_defaults() -> None:
+    input_ = {"foo": {"defaults": {1: 1}, "other": {}}}
+    expected = {"other": {1: 1}}
+    output = _apply_defaults_to_subtables(input_, table="foo")
+    assert expected == output
+
+
+def test_apply_defaults_to_subtables_does_not_override() -> None:
+    input_ = {"foo": {"defaults": {1: 1}, "other": {1: 2}}}
+    expected = {"other": {1: 2}}
+    output = _apply_defaults_to_subtables(input_, table="foo")
+    assert expected == output
+
+
+def test_load_configuration_adds_environment_variables(default_configuration_file: Path) -> None:
+    database_configuration = load_database_configuration(default_configuration_file)
+    assert database_configuration["openml"]["username"] == "root"
+
+    load_database_configuration.cache_clear()
+    os.environ["OPENML_DATABASES_OPENML_USERNAME"] = "foo"
+    database_configuration = load_database_configuration(default_configuration_file)
+    assert database_configuration["openml"]["username"] == "foo"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,27 @@
 import json
-import pathlib
+from pathlib import Path
 from typing import Any, Generator
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from main import app
 
 
 @pytest.fixture()
 def api_client() -> Generator[FastAPI, None, None]:
+    # We want to avoid starting a test client app if tests don't need it.
+    from main import app
+
     return TestClient(app)
 
 
 @pytest.fixture()
 def dataset_130() -> Generator[dict[str, Any], None, None]:
-    json_path = pathlib.Path(__file__).parent / "resources" / "datasets" / "dataset_130.json"
+    json_path = Path(__file__).parent / "resources" / "datasets" / "dataset_130.json"
     with json_path.open("r") as dataset_file:
         yield json.load(dataset_file)
+
+
+@pytest.fixture()
+def default_configuration_file() -> Path:
+    return Path().parent.parent / "src" / "config.toml"


### PR DESCRIPTION
This PR makes the database connection configurable through a configuration file (currently located at `src/config.toml`). The database credentials must be set through environment variables instead (which may be in a `.env` file). I am not happy with this implementation, but figured I would share for input.

We need our connections to be configurable as this will make it easier to set up in different environments (e.g., different developers, or staging vs production). For a lot of these values, we can provide sensible defaults which will work with the default development environment. Providing these defaults through an example configuration file makes it immediately easy to understand what is configurable. 

It would then also be convenient to provide an easy way to override the configuration of the shipped configuration, which could be either through environment variables, or a separate configuration file (for example, by default located in something like `~/.config/openml-server` or a file explicitly passed as command line argument). This is currently not supported.

I also excluded credentials from this file, since I do not want people to accidentally share credentials. This is why I put them in environment variables, but we could also work with a separate credentials file. In practice this would be the same (when working  with `.env` files), so I don't really think this matters.

For the database connections we would expect information to be duplicate (e.g., where it server is located). However, `toml` does not support defaults natively, which is why I added a `defaults` subtable which propagates its values to sibling tables. I doubt that the added complexity is warranted (at this point), but I wanted to make it easier for myself to switch between the my local test server snapshot and the production server snapshot (that will be hosted in k8s).

I also think it might be useful to parse the configuration into some Pydantic class in the future to catch invalid configurations earlier and, for non-database configurations which may be used more frequently in the program, to access configurations through typed objects rather than dictionaries to aid IDE features.

