### PR TITLE
Refactor app startup, `POST data/tag` endpoint now requires body

### DIFF
--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -10,5 +10,5 @@ RUN python -m pip install --upgrade pip
 RUN python -m pip install -e ".[dev]"
 
 EXPOSE 8000
-ENTRYPOINT ["uvicorn"]
-CMD ["src.main:app", "--host", "0.0.0.0", "--reload"]
+ENTRYPOINT ["python", "src/main.py"]
+CMD ["--host", "0.0.0.0", "--reload"]

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,6 +35,12 @@ and JSON content will be different.
 + {"detail":[{"loc":["query","_dataset_id"],"msg":"value is not a valid integer","type":"type_error.integer"}]}
 ```
 
+!!! Bug "Input validation has been added to many end points"
+
+   There are endpoints which previously did not do any input validation.
+   These endpoints now do enforce stricter input constraints.
+   Constraints for each endpoint parameter are documented in the API docs.
+
 #### Other Errors
 For any other error messages, the response is identical except that outer field will be `"detail"` instead of `"error"`:
 
@@ -45,6 +51,7 @@ For any other error messages, the response is identical except that outer field 
 
 In some cases the JSON endpoints previously returned XML ([example](https://github.com/openml/OpenML/issues/1200)).
 Python-V1 will always return JSON.
+
 
 ```diff title="XML replaced by JSON"
 - <oml:error xmlns:oml="http://openml.org/openml">

--- a/src/database/setup.py
+++ b/src/database/setup.py
@@ -8,10 +8,11 @@ _expdb_engine = None
 
 def _create_engine(database_name: str) -> Engine:
     database_configuration = load_database_configuration()
+    echo = database_configuration[database_name].pop("echo", False)
     db_url = URL.create(**database_configuration[database_name])
     return create_engine(
         db_url,
-        echo=True,
+        echo=echo,
         pool_recycle=3600,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,10 +1,58 @@
+import argparse
+
+import uvicorn
 from fastapi import FastAPI
 from routers.mldcat_ap.dataset import router as mldcat_ap_router
 from routers.v1.datasets import router as datasets_router_old_format
 from routers.v2.datasets import router as datasets_router
 
-app = FastAPI()
 
-app.include_router(datasets_router)
-app.include_router(datasets_router_old_format)
-app.include_router(mldcat_ap_router)
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    uvicorn_options = parser.add_argument_group(
+        "uvicorn",
+        "arguments forwarded to uvicorn",
+    )
+    uvicorn_options.add_argument(
+        "--reload",
+        action="store_true",
+        help="Enable auto-reload",
+    )
+    uvicorn_options.add_argument(
+        "--host",
+        default="127.0.0.1",
+        type=str,
+        help="Bind socket to this host.",
+    )
+    uvicorn_options.add_argument(
+        "--port",
+        default=8000,
+        type=int,
+        help="Bind socket to this port. If 0, an available port will be picked.",
+    )
+    return parser.parse_args()
+
+
+def create_api() -> FastAPI:
+    app = FastAPI()
+
+    app.include_router(datasets_router)
+    app.include_router(datasets_router_old_format)
+    app.include_router(mldcat_ap_router)
+
+    return app
+
+
+def main() -> None:
+    args = _parse_args()
+    uvicorn.run(
+        app="main:create_api",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+        factory=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/routers/types.py
+++ b/src/routers/types.py
@@ -1,8 +1,8 @@
 from typing import Annotated
 
-from fastapi import Query
+from fastapi import Body
 
 SystemString64 = Annotated[
     str,
-    Query(pattern=r"^[a-zA-Z0-9_\-\.]+$", min_length=1, max_length=64),
+    Body(pattern=r"^[a-zA-Z0-9_\-\.]+$", min_length=1, max_length=64),
 ]

--- a/src/routers/v1/datasets.py
+++ b/src/routers/v1/datasets.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 from database.datasets import get_tags
 from database.datasets import tag_dataset as db_tag_dataset
 from database.users import APIKey, User
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
 from sqlalchemy import Connection
 
 from routers.dependencies import expdb_connection, fetch_user, userdb_connection
@@ -79,13 +79,13 @@ def get_dataset_wrapped(
     path="/tag",
 )
 def tag_dataset(
-    data_id: int,
+    data_id: Annotated[int, Body()],
     tag: SystemString64,
     user: Annotated[User | None, Depends(fetch_user)] = None,
     expdb_db: Annotated[Connection, Depends(expdb_connection)] = None,
 ) -> dict[str, dict[str, Any]]:
     tags = get_tags(data_id, expdb_db)
-    if tag in tags:
+    if tag.casefold() in [t.casefold() for t in tags]:
         raise HTTPException(
             status_code=http.client.INTERNAL_SERVER_ERROR,
             detail={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ from typing import Any, Generator
 
 import pytest
 from database.setup import expdb_database, user_database
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from main import create_api
 from routers.dependencies import expdb_connection, userdb_connection
@@ -41,7 +40,7 @@ def user_test() -> Connection:
 
 
 @pytest.fixture()
-def api_client(expdb_test: Connection, user_test: Connection) -> Generator[FastAPI, None, None]:
+def api_client(expdb_test: Connection, user_test: Connection) -> TestClient:
     app = create_api()
     # We use the lambda definitions because fixtures may not be called directly.
     app.dependency_overrides[expdb_connection] = lambda: expdb_test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 from enum import StrEnum
 from pathlib import Path
@@ -7,8 +8,9 @@ import pytest
 from database.setup import expdb_database, user_database
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from main import create_api
 from routers.dependencies import expdb_connection, userdb_connection
-from sqlalchemy import Connection
+from sqlalchemy import Connection, Engine
 
 
 class ApiKey(StrEnum):
@@ -18,27 +20,29 @@ class ApiKey(StrEnum):
     INVALID: str = "11111111111111111111111111111111"
 
 
-@pytest.fixture()
-def expdb_test() -> Connection:
-    with expdb_database().connect() as connection:
+@contextlib.contextmanager
+def automatic_rollback(engine: Engine) -> Generator[Connection, None, None]:
+    with engine.connect() as connection:
         transaction = connection.begin()
         yield connection
         transaction.rollback()
+
+
+@pytest.fixture()
+def expdb_test() -> Connection:
+    with automatic_rollback(expdb_database()) as connection:
+        yield connection
 
 
 @pytest.fixture()
 def user_test() -> Connection:
-    with user_database().connect() as connection:
-        transaction = connection.begin()
+    with automatic_rollback(user_database()) as connection:
         yield connection
-        transaction.rollback()
 
 
 @pytest.fixture()
 def api_client(expdb_test: Connection, user_test: Connection) -> Generator[FastAPI, None, None]:
-    # We want to avoid starting a test client app if tests don't need it.
-    from main import app
-
+    app = create_api()
     # We use the lambda definitions because fixtures may not be called directly.
     app.dependency_overrides[expdb_connection] = lambda: expdb_test
     app.dependency_overrides[userdb_connection] = lambda: user_test

--- a/tests/routers/v1/dataset_tag_test.py
+++ b/tests/routers/v1/dataset_tag_test.py
@@ -4,8 +4,8 @@ from typing import cast
 import httpx
 import pytest
 from database.datasets import get_tags
-from fastapi import FastAPI
 from sqlalchemy import Connection
+from starlette.testclient import TestClient
 
 from tests.conftest import ApiKey
 
@@ -15,12 +15,13 @@ from tests.conftest import ApiKey
     [None, ApiKey.INVALID],
     ids=["no authentication", "invalid key"],
 )
-def test_dataset_tag_rejects_unauthorized(key: ApiKey, api_client: FastAPI) -> None:
-    apikey = "" if key is None else f"&api_key={key}"
+def test_dataset_tag_rejects_unauthorized(key: ApiKey, api_client: TestClient) -> None:
+    apikey = "" if key is None else f"?api_key={key}"
     response = cast(
         httpx.Response,
         api_client.post(
-            f"/v1/datasets/tag?data_id=130&tag=test{apikey}",
+            f"/v1/datasets/tag{apikey}",
+            json={"data_id": 130, "tag": "test"},
         ),
     )
     assert response.status_code == http.client.PRECONDITION_FAILED
@@ -32,7 +33,7 @@ def test_dataset_tag_rejects_unauthorized(key: ApiKey, api_client: FastAPI) -> N
     [ApiKey.ADMIN, ApiKey.REGULAR_USER, ApiKey.OWNER_USER],
     ids=["administrator", "non-owner", "owner"],
 )
-def test_dataset_tag(key: ApiKey, expdb_test: Connection, api_client: FastAPI) -> None:
+def test_dataset_tag(key: ApiKey, expdb_test: Connection, api_client: TestClient) -> None:
     dataset_id, tag = 130, "test"
     response = cast(
         httpx.Response,
@@ -47,7 +48,7 @@ def test_dataset_tag(key: ApiKey, expdb_test: Connection, api_client: FastAPI) -
     assert tag in tags
 
 
-def test_dataset_tag_returns_existing_tags(api_client: FastAPI) -> None:
+def test_dataset_tag_returns_existing_tags(api_client: TestClient) -> None:
     dataset_id, tag = 1, "test"
     response = cast(
         httpx.Response,
@@ -59,7 +60,7 @@ def test_dataset_tag_returns_existing_tags(api_client: FastAPI) -> None:
     assert {"data_tag": {"id": str(dataset_id), "tag": ["study_14", tag]}} == response.json()
 
 
-def test_dataset_tag_fails_if_tag_exists(api_client: FastAPI) -> None:
+def test_dataset_tag_fails_if_tag_exists(api_client: TestClient) -> None:
     dataset_id, tag = 1, "study_14"  # Dataset 1 already is tagged with 'study_14'
     response = cast(
         httpx.Response,
@@ -85,7 +86,7 @@ def test_dataset_tag_fails_if_tag_exists(api_client: FastAPI) -> None:
 )
 def test_dataset_tag_invalid_tag_is_rejected(
     tag: str,
-    api_client: FastAPI,
+    api_client: TestClient,
 ) -> None:
     query = f"data_id=1&tag={tag}&api_key={ApiKey.ADMIN}"
     new = cast(httpx.Response, api_client.post(f"/v1/datasets/tag?{query}"))
@@ -97,7 +98,7 @@ def test_dataset_tag_invalid_tag_is_rejected(
 @pytest.mark.php()
 @pytest.mark.parametrize(
     "dataset_id",
-    list(range(1, 130)),
+    list(range(1, 10)) + [101],
 )
 @pytest.mark.parametrize(
     "api_key",
@@ -113,7 +114,7 @@ def test_dataset_tag_response_is_identical(
     dataset_id: int,
     tag: str,
     api_key: str,
-    api_client: FastAPI,
+    api_client: TestClient,
 ) -> None:
     query = f"data_id={dataset_id}&tag={tag}&api_key={api_key}"
     original = httpx.post(

--- a/tests/routers/v1/datasets_old_test.py
+++ b/tests/routers/v1/datasets_old_test.py
@@ -4,7 +4,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from starlette.testclient import TestClient
 
 
 @pytest.mark.php()
@@ -12,7 +12,7 @@ from fastapi import FastAPI
     "dataset_id",
     range(1, 132),
 )
-def test_dataset_response_is_identical(dataset_id: int, api_client: FastAPI) -> None:
+def test_dataset_response_is_identical(dataset_id: int, api_client: TestClient) -> None:
     original = httpx.get(f"http://server-api-php-api-1:80/api/v1/json/data/{dataset_id}")
     new = cast(httpx.Response, api_client.get(f"/v1/datasets/{dataset_id}"))
     assert original.status_code == new.status_code
@@ -59,7 +59,7 @@ def test_dataset_response_is_identical(dataset_id: int, api_client: FastAPI) -> 
 )
 def test_error_unknown_dataset(
     dataset_id: int,
-    api_client: FastAPI,
+    api_client: TestClient,
 ) -> None:
     response = cast(httpx.Response, api_client.get(f"v1/datasets/{dataset_id}"))
 
@@ -72,7 +72,7 @@ def test_error_unknown_dataset(
     [None, "a" * 32],
 )
 def test_private_dataset_no_user_no_access(
-    api_client: FastAPI,
+    api_client: TestClient,
     api_key: str | None,
 ) -> None:
     query = f"?api_key={api_key}" if api_key else ""
@@ -84,7 +84,7 @@ def test_private_dataset_no_user_no_access(
 
 @pytest.mark.skip("Not sure how to include apikey in test yet.")
 def test_private_dataset_owner_access(
-    api_client: FastAPI,
+    api_client: TestClient,
     dataset_130: dict[str, Any],
 ) -> None:
     response = cast(httpx.Response, api_client.get("/v1/datasets/130?api_key=..."))
@@ -93,6 +93,6 @@ def test_private_dataset_owner_access(
 
 
 @pytest.mark.skip("Not sure how to include apikey in test yet.")
-def test_private_dataset_admin_access(api_client: FastAPI) -> None:
+def test_private_dataset_admin_access(api_client: TestClient) -> None:
     cast(httpx.Response, api_client.get("/v1/datasets/130?api_key=..."))
     # test against cached response

--- a/tests/routers/v2/datasets_test.py
+++ b/tests/routers/v2/datasets_test.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from starlette.testclient import TestClient
 
 
 @pytest.mark.parametrize(
@@ -17,7 +17,7 @@ from fastapi import FastAPI
 def test_error_unknown_dataset(
     dataset_id: int,
     response_code: int,
-    api_client: FastAPI,
+    api_client: TestClient,
 ) -> None:
     response = cast(httpx.Response, api_client.get(f"v2/datasets/{dataset_id}"))
 
@@ -33,7 +33,7 @@ def test_error_unknown_dataset(
     ],
 )
 def test_private_dataset_no_user_no_access(
-    api_client: FastAPI,
+    api_client: TestClient,
     api_key: str | None,
     response_code: int,
 ) -> None:
@@ -46,7 +46,7 @@ def test_private_dataset_no_user_no_access(
 
 @pytest.mark.skip("Not sure how to include apikey in test yet.")
 def test_private_dataset_owner_access(
-    api_client: FastAPI,
+    api_client: TestClient,
     dataset_130: dict[str, Any],
 ) -> None:
     response = cast(httpx.Response, api_client.get("/v2/datasets/130?api_key=..."))
@@ -55,6 +55,6 @@ def test_private_dataset_owner_access(
 
 
 @pytest.mark.skip("Not sure how to include apikey in test yet.")
-def test_private_dataset_admin_access(api_client: FastAPI) -> None:
+def test_private_dataset_admin_access(api_client: TestClient) -> None:
     cast(httpx.Response, api_client.get("/v2/datasets/130?api_key=..."))
     # test against cached response


### PR DESCRIPTION
The FastAPI app is now created from a function instead on import.

The `POST data/tag` endpoint now requires input through the request body instead of query parameters (except for authentication, which will be changed later).