### PR TITLE
Docker/bake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'docker/**'
+      - 'docker-compose.yaml'
+      - '.github/workflows/tests.yml'
+
+permissions:
+  contents: write
+
+jobs:
+  compare-php:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+
+      # A naive `docker compose up` would first build the `python-api` container and then
+      # start all services, which kickstarts Elastic Search and building indices.
+      # But since those two steps are independent, we can parallelize them to save time.
+      - run: |
+          { docker compose build python-api; docker compose up -d python-api; } &
+          docker compose up -d --wait php-api
+      - run: docker container ls
+      - run: docker exec python-api python -m pytest -xv -m "php"
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: docker compose up -d --wait database python-api
+      - run: docker container ls
+      - run: docker exec python-api python -m pytest -xv -m "not php"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,17 @@ services:
       context: ./docker/php/
     ports:
       - "8002:80"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+      database:
+        condition: service_started
+    healthcheck:
+      test: curl 127.0.0.1:80 | grep -e "openml"
+      start_period: 30s
+      start_interval: 5s
+      timeout: 3s
+      interval: 1m
 
   python-api:
     container_name: "python-api"
@@ -32,9 +43,11 @@ services:
       - "8001:8000"
     volumes:
       - .:/python-api
+    depends_on:
+      - database
 
   elasticsearch:
-    image: openml/elasticsearch8-prebuilt
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.4
     container_name: "elasticsearch"
     ports:
       - "9200:9200"
@@ -43,3 +56,9 @@ services:
       - ELASTIC_PASSWORD=default
       - discovery.type=single-node
       - xpack.security.enabled=false
+    healthcheck:
+      test: curl 127.0.0.1:9200/_cluster/health | grep -e "green"
+      start_period: 30s
+      start_interval: 5s
+      timeout: 3s
+      interval: 1m

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,19 +34,12 @@ services:
       - .:/python-api
 
   elasticsearch:
-    image: "docker.elastic.co/elasticsearch/elasticsearch:8.10.4"
+    image: openml/elasticsearch8-prebuilt
     container_name: "elasticsearch"
     ports:
       - "9200:9200"
       - "9300:9300"
-    volumes:
-      - esdata:/usr/share/elasticsearch/data
-      - certs:/usr/share/elasticsearch/config/data
     environment:
       - ELASTIC_PASSWORD=default
       - discovery.type=single-node
       - xpack.security.enabled=false
-
-volumes:
-  esdata:
-  certs:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
 
   php-api:
     image: "openml/php-rest-api"
+    build:
+      context: ./docker/php/
     ports:
       - "8002:80"
 

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -6,10 +6,16 @@ COPY ./data /docker-entrypoint-initdb.d
 # first start up. To do this, we run the default entry point script with `mysqld` as
 # first argument, as this kickstarts the database initialisation. But this also forces
 # `mysqld` to start after database initialization, which we don't want. So we automatically kill
-# the process after 60 seconds, which should be enough time to initialize the database.
+# the process after 180 seconds, which should be enough time to initialize the database.
 # c.f. https://github.com/docker-library/mysql/blob/master/8.0/docker-entrypoint.sh
-RUN MYSQL_ROOT_PASSWORD=ok \
-    timeout --preserve-status 60 \
-    bash /usr/local/bin/docker-entrypoint.sh mysqld
+#
+# I am a little unsure about the next bit, but it works:
+# Multi-architecture builds will execute this within the same build environment,
+# which means each architecture needs to host their `mysqld` on their own port
+# otherwise one of the two will error during the build process as the port is already taken.
+RUN if [ $(uname -m) = "x86_64" ]; then export PORT=3036; else export PORT=30306; fi \
+    && MYSQL_ROOT_PASSWORD=ok \
+    timeout --preserve-status 180 \
+    bash /usr/local/bin/docker-entrypoint.sh mysqld --port=${PORT}
 
 RUN rm /docker-entrypoint-initdb.d/*

--- a/docker/mysql/Dockerfile
+++ b/docker/mysql/Dockerfile
@@ -1,3 +1,15 @@
 FROM mysql
 
 COPY ./data /docker-entrypoint-initdb.d
+
+# We want to bake the database state into the image, as it saves ~30 seconds on
+# first start up. To do this, we run the default entry point script with `mysqld` as
+# first argument, as this kickstarts the database initialisation. But this also forces
+# `mysqld` to start after database initialization, which we don't want. So we automatically kill
+# the process after 60 seconds, which should be enough time to initialize the database.
+# c.f. https://github.com/docker-library/mysql/blob/master/8.0/docker-entrypoint.sh
+RUN MYSQL_ROOT_PASSWORD=ok \
+    timeout --preserve-status 60 \
+    bash /usr/local/bin/docker-entrypoint.sh mysqld
+
+RUN rm /docker-entrypoint-initdb.d/*

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -6,10 +6,7 @@ RUN docker-php-source extract \
 
 RUN apt-get update \
     && apt-get install -y git \
-    && git clone https://github.com/openml/openml /var/www/openml
-
-WORKDIR /var/www/openml
-RUN git checkout feature/elasticsearch8
+    && git clone --branch feature/elasticsearch8 https://github.com/openml/openml /var/www/openml
 
 RUN mv /var/www/openml/openml_OS/config/BASE_CONFIG-BLANK.php /var/www/openml/openml_OS/config/BASE_CONFIG.php
 

--- a/docker/php/set_configuration.sh
+++ b/docker/php/set_configuration.sh
@@ -26,4 +26,7 @@ sed "s*'ES_URL', 'FILL_IN'*'ES_URL', '${ES_URL:-elasticsearch:9200}'*g" --in-pla
 sed "s*'ES_USERNAME', 'FILL_IN'*'ES_USERNAME', '${ES_USERNAME:-elastic}'*g" --in-place ${BASE_CONFIG_PATH}
 sed "s*'ES_PASSWORD', 'FILL_IN'*'ES_PASSWORD', '${ES_PASSWORD:-default}'*g" --in-place ${BASE_CONFIG_PATH}
 
+cd /var/www/openml
+php index.php cron build_es_indices
+
 apache2-foreground

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,38 @@
+# OpenML Docker Images
+This directory contains the files and information to build the following 5 images:
+
+ - [openml/test-database](https://hub.docker.com/r/openml/test-database): the official
+    [mysql](https://hub.docker.com/_/mysql) image, but with the test database already
+    baked into the image to significantly reduce startup times.
+ - docs: the official [mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material)
+    image but with additional plugins installed required for building the documentation
+    in this project's `/doc` directory.
+ - [openml/php-rest-api](https://hub.docker.com/r/openml/php-rest-api): image with the
+    php back-end code, but ran on [feature/elasticsearch8](https://github.com/openml/openml/tree/feature/elasticsearch8)
+    branch.
+ - python-api: an image of this project, to facilitate development on any platform.
+ - [openml/elasticsearch8-prebuilt](https://hub.docker.com/r/openml/elasticsearch8-prebuilt):
+    the default elasticsearch image, but with indices already built on the test database
+    through invocation of the old php code.
+
+Between the prebuilt indices and the baked-in database, when all images have already been
+pulled, a `docker compose up` step should only take seconds. 🚀
+
+## Building `openml/elasticsearch8-prebuilt`
+The `openml/elasticsearch8-prebuilt` is not made with a Dockerfile, because it requires
+steps of running containers, which to the best of my knowledge is not facilitated by
+docker (not even through [multi-stage builds](https://docs.docker.com/build/building/multi-stage/)).
+So, instead we build the container state locally and then use [`docker commit`](https://docs.docker.com/engine/reference/commandline/commit/).
+
+1. run `docker compose up`, but with the `elasticsearch` service pointing to
+    `docker.elastic.co/elasticsearch/elasticsearch:8.10.4` instead of `openml/elasticsearch8-prebuilt`.
+2. build the indices from the `php-api` container:
+
+   1. Connect to the container: `docker exec -it server-api-php-api-1 /bin/bash`
+   2. (optional) Edit `/var/www/openml/index.php` and set L56 to `development` instead of `production`,
+       this will show progress of building the indices, or print out any error that may occur.
+   3. Build the indices: `php /var/www/openml/index.php cron build_es_indices`
+   4. Exit the container with `exit`.
+
+3. Make a commit of the elastic search container with prebuilt indices: `docker commit elasticsearch openml/elasticsearch8-prebuilt`
+4. Push the image created by the commit: `docker push openml/elasticsearch8-prebuilt`

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -36,3 +36,12 @@ So, instead we build the container state locally and then use [`docker commit`](
 
 3. Make a commit of the elastic search container with prebuilt indices: `docker commit elasticsearch openml/elasticsearch8-prebuilt`
 4. Push the image created by the commit: `docker push openml/elasticsearch8-prebuilt`
+
+## Building for multiple platforms
+
+Following Docker's "[multi-platform images](https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiTutyczsOCAxUUhv0HHe_VA6QQFnoECBAQAQ&url=https%3A%2F%2Fdocs.docker.com%2Fbuild%2Fbuilding%2Fmulti-platform%2F&usg=AOvVaw0YP_mkj5WTYD-0weEfrfDv&opi=89978449)"
+documentation, we can build multi-platform images in a few simple steps:
+
+1. Only the first time, create a docker-container driver: `docker buildx create --name container --driver=docker-container`
+2. Use `docker buildx` to build for multiple target platforms: `docker buildx build --builder=container --platform=linux/amd64,linux/arm64 -t openml/test-database docker/mysql`
+3. If you want to push the images to Dockerhub, run the command above with the added `--push` option.


### PR DESCRIPTION
Bake data into docker images to significantly reduce startup time and/or reduce complexity of getting the setup up and running.

Bake in the OpenML test database data into the `openml/test-database` image (instead of the `.sql` files which would need to be executed on a first start up), reducing startup time by ~30 seconds.
Bake in the elastic search indices for the elastic search 8 image. Unfortunately, I could not find a way to automate this so I provided instructions on how to recreate this (I figure I could write scripts which simulate this, but at that point I don't think the time spent automating that is worth it, so instructions made more sense to me).