### PR TITLE
Add/get task

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlalchemy",
     "mysqlclient",
     "python_dotenv",
+    "xmltodict",
 ]
 
 [project.optional-dependencies]

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from routers.openml.datasets import router as datasets_router
 from routers.openml.estimation_procedure import router as estimationprocedure_router
 from routers.openml.evaluations import router as evaluationmeasures_router
 from routers.openml.qualities import router as qualities_router
+from routers.openml.tasks import router as task_router
 from routers.openml.tasktype import router as ttype_router
 
 
@@ -45,6 +46,7 @@ def create_api() -> FastAPI:
     app.include_router(ttype_router)
     app.include_router(evaluationmeasures_router)
     app.include_router(estimationprocedure_router)
+    app.include_router(task_router)
     return app
 
 

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/tasks", tags=["tasks"])
+
+
+@router.get("/{task_id}")
+def get_task(
+    # task_id: int,
+    # user: Annotated[User | None, Depends(fetch_user)] = None,
+    # expdb: Annotated[Connection, Depends(expdb_connection)] = None,
+) -> dict[str, Any]:
+    return {}

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -1,14 +1,225 @@
-from typing import Any
+import re
+from typing import Any, Annotated
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from pydantic import Json
+from sqlalchemy import Connection, text
+
+from database.datasets import get_dataset
+from database.users import User
+from routers.dependencies import fetch_user, expdb_connection
+from schemas.datasets.openml import Task
+import xmltodict
+
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
+def convert_template(xml_template: str) -> Json:
+    json_template = xmltodict.parse(xml_template.replace("oml:", ""))
+    # To account for the differences between PHP and Python conversions:
+    inner_dict = list(json_template.values())[0]
+    for parameter in inner_dict.get("parameter", []):
+        parameter["name"] = parameter.pop("@name")
+        parameter["value"] = parameter.pop("#text")
+    return json_template
+
+
+def fill_template(template: str, task, task_inputs, connection: Connection):
+    """ Fill in the XML template as used for task descriptions.
+
+    template, str:
+        A string represent XML, as detailed below.
+    task, ?:
+        The `task` for which to fill in the template.
+    task_inputs, dict:
+        The `task_input` entries where keys correspond to `input` and values
+        correspond to `value`.
+
+    returns: str
+        The template with values filled in.
+
+
+    The template is an XML template that specifies which information to show to the user,
+    and where to fetch it from. For example:
+
+    <oml:estimation_procedure>
+      <oml:id>[INPUT:estimation_procedure]</oml:id>
+      <oml:type>[LOOKUP:estimation_procedure.type]</oml:type>
+      <oml:data_splits_url>[CONSTANT:base_url]api_splits/get/[TASK:id]/Task_[TASK:id]_splits.arff</oml:data_splits_url>  # noqa: E501
+      <oml:parameter name="number_repeats">[LOOKUP:estimation_procedure.repeats]</oml:parameter>
+      <oml:parameter name="number_folds">[LOOKUP:estimation_procedure.folds]</oml:parameter>
+    </oml:estimation_procedure>
+
+    Here, we encounter the following directives:
+      - [INPUT:X] specifies that should be replaced by the `value` from the
+        `task_inputs` table where `input`=X.
+      - [LOOKUP:A.B] specifies that it should be replaced by the value in
+        column `B` of table `A` in the row where `A.id` equals the `value`
+        from the `task_inputs` table where `input`=A.
+      - [CONSTANT:a] is replaced by a constant 'a' known by the PHP API.
+      - [TASK:id] is replaced by the task id.
+
+    Resulting JSON could look like:
+
+    "estimation_procedure": {
+        "id": 5,
+        "type": "crossvalidation",
+        "data_splits_url": "https://test.openml.org/api_splits/get/1/Task_1_splits.arff"
+        "parameter": [
+            {"name": "number_repeats", "value": 1},
+            {"name": "number_folds", "value: 10},
+        ]
+    }
+    """
+    fetched_data = {}
+    lines = []
+    for line in template.splitlines():
+        if match := re.search(r"\[INPUT:(.*)]", line):
+            (field,) = match.groups()
+            # Does it need to exist, or can it be unspecified? i.e. [x] vs .get(x)
+            line = line.replace(match.group(), task_inputs[field])
+        if match := re.search(r"\[LOOKUP:(.*)]", line):
+            (field,) = match.groups()
+            if field not in fetched_data:
+                table, _ = field.split(".")
+                rows = connection.execute(
+                    text(
+                        f"""
+                        SELECT *
+                        FROM {table}
+                        WHERE `id` = :id_
+                        """
+                    ), parameters={"id_": int(task_inputs[table])}
+                )
+                for column, value in next(rows.mappings()).items():
+                    # Because of string replacement, the value needs to be a string
+                    # can not easily rectify without first converting the XML to JSON
+                    fetched_data[f"{table}.{column}"] = str(value)
+            line = line.replace(match.group(), fetched_data[field])
+        line = line.replace("[TASK:id]", str(task.task_id))
+        line = line.replace("[CONSTANT:base_url]", "get_the_right_base_url")
+        lines.append(line)
+    return '\n'.join(lines)
+
+
 @router.get("/{task_id}")
 def get_task(
-    # task_id: int,
-    # user: Annotated[User | None, Depends(fetch_user)] = None,
-    # expdb: Annotated[Connection, Depends(expdb_connection)] = None,
-) -> dict[str, Any]:
-    return {}
+    task_id: int,
+    user: Annotated[User | None, Depends(fetch_user)] = None,
+    expdb: Annotated[Connection, Depends(expdb_connection)] = None,
+) -> Task:
+    # fetch primary task metadata
+    task_row = expdb.execute(
+        text(
+            """
+            SELECT *
+            FROM task
+            WHERE `task_id` = :task_id
+            """
+        ), parameters={"task_id": task_id}
+    )
+    task = next(task_row.mappings())
+    # fetch secondary task metadata
+    task_type_row = expdb.execute(
+        text(
+            """
+            SELECT * 
+            FROM task_type
+            WHERE `ttid` = :task_type_id
+            """
+        ), parameters={"task_type_id": task.ttid}
+    )
+    task_type = next(task_type_row)
+    input_rows = expdb.execute(
+        text(
+            """
+            SELECT `input`, `value`
+            FROM task_inputs
+            WHERE task_id = :task_id
+            """
+        ), parameters={"task_id": task_id}
+    )
+    inputs = {row.input: row.value for row in input_rows}
+    ttios = expdb.execute(
+        text(
+            """
+            SELECT *
+            FROM task_type_inout
+            WHERE `ttid` = :task_type_id AND `template_api` IS NOT NULL
+            """
+        ), parameters={"task_type_id": task.ttid}
+    )
+    # breakpoint()
+    # Have a look at "hidden" requirements. Do we ignore them at this stage?
+    # templates = [
+    #     (tt_io.name, tt_io.io, tt_io.requirement, tt_io.template)
+    #     for tt_io in ttios
+    # ]
+    # inputs = [
+    #     fill_template(template, task, )
+    #     for name, io, required, template in templates
+    #     if io == "input" and (required == "required" or name in inputs)
+    # ]
+    # outputs = [
+    #     fill_template(template)
+    #     for name, io, required, template in templates
+    #     if io == "output"
+    # ]
+    fs = []
+    for tt_io in ttios:
+        if tt_io.name not in inputs and tt_io.requirement == "optional":
+            continue
+        fs.append(fill_template(
+            tt_io.template_api,
+            task,
+            inputs,
+            expdb,
+        ))
+    breakpoint()
+    # def get_task_input_output():
+    #     ttios = expdb.execute(
+    #         text(
+    #             """
+    #             SELECT *
+    #             FROM task_type_inout
+    #             WHERE `ttid` = :task_type_id AND `template_api` IS NOT NULL
+    #             """
+    #         ), parameters={"task_type_id": task.ttid}
+    #     )
+    #     for tt_io in ttios:
+    #         tt_io.template_api
+    #         {
+    #             "name": tt_io.name,
+    #             <template>
+    #         }
+    # for table, identifier in inputs.items():
+    #     ...
+    # [CONSTANT: base_url]api_splits / get / [TASK: id] / Task_[TASK:id]
+    # _splits.arff
+    # if custom_testset is part, then raise error
+    # get tasktype io
+    tag_rows = expdb.execute(
+        text(
+            """
+            SELECT `tag`
+            FROM task_tag
+            WHERE `id` = :task_id 
+            """
+        ), parameters={"task_id": task_id}
+    )
+    tags = [row.tag for row in tag_rows]
+    name = f"Task {task_id} ({task_type.name})"
+    if dataset_id := inputs.get("source_data"):
+        dataset = get_dataset(dataset_id, expdb)
+        name = f"Task {task_id}:  {dataset['name']} ({task_type.name})"
+
+    return Task(
+        id_=task.task_id,
+        name=name,
+        task_type_id=task.ttid,
+        task_type=task_type.name,
+        input_=[inputs],
+        output={},
+        tags=tags,
+    )

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -1,32 +1,35 @@
+import json
 import re
-from typing import Any, Annotated
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
-from pydantic import Json
-from sqlalchemy import Connection, text
-
-from database.datasets import get_dataset
-from database.users import User
-from routers.dependencies import fetch_user, expdb_connection
-from schemas.datasets.openml import Task
 import xmltodict
+from database.datasets import get_dataset
+from fastapi import APIRouter, Depends
+from schemas.datasets.openml import Task
+from sqlalchemy import Connection, RowMapping, text
 
+from routers.dependencies import expdb_connection
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-def convert_template(xml_template: str) -> Json:
+def convert_template_xml_to_json(xml_template: str) -> Any:
     json_template = xmltodict.parse(xml_template.replace("oml:", ""))
+    json_str = json.dumps(json_template)
     # To account for the differences between PHP and Python conversions:
-    inner_dict = list(json_template.values())[0]
-    for parameter in inner_dict.get("parameter", []):
-        parameter["name"] = parameter.pop("@name")
-        parameter["value"] = parameter.pop("#text")
-    return json_template
+    for py, php in [("@name", "name"), ("#text", "value"), ("@type", "type")]:
+        json_str = json_str.replace(py, php)
+    return json.loads(json_str)
 
 
-def fill_template(template: str, task, task_inputs, connection: Connection):
-    """ Fill in the XML template as used for task descriptions.
+def fill_template(
+    template: str,
+    task: RowMapping,
+    task_inputs: dict[str, str],
+    connection: Connection,
+) -> Any:
+    """Fill in the XML template as used for task descriptions and return the result,
+     converted to JSON.
 
     template, str:
         A string represent XML, as detailed below.
@@ -46,7 +49,7 @@ def fill_template(template: str, task, task_inputs, connection: Connection):
     <oml:estimation_procedure>
       <oml:id>[INPUT:estimation_procedure]</oml:id>
       <oml:type>[LOOKUP:estimation_procedure.type]</oml:type>
-      <oml:data_splits_url>[CONSTANT:base_url]api_splits/get/[TASK:id]/Task_[TASK:id]_splits.arff</oml:data_splits_url>  # noqa: E501
+      <oml:data_splits_url>[CONSTANT:base_url]api_splits/get/[TASK:id]/Task_[TASK:id]_splits.arff</oml:data_splits_url>
       <oml:parameter name="number_repeats">[LOOKUP:estimation_procedure.repeats]</oml:parameter>
       <oml:parameter name="number_folds">[LOOKUP:estimation_procedure.folds]</oml:parameter>
     </oml:estimation_procedure>
@@ -71,42 +74,76 @@ def fill_template(template: str, task, task_inputs, connection: Connection):
             {"name": "number_folds", "value: 10},
         ]
     }
-    """
-    fetched_data = {}
-    lines = []
-    for line in template.splitlines():
-        if match := re.search(r"\[INPUT:(.*)]", line):
-            (field,) = match.groups()
-            # Does it need to exist, or can it be unspecified? i.e. [x] vs .get(x)
-            line = line.replace(match.group(), task_inputs[field])
-        if match := re.search(r"\[LOOKUP:(.*)]", line):
-            (field,) = match.groups()
-            if field not in fetched_data:
-                table, _ = field.split(".")
-                rows = connection.execute(
-                    text(
-                        f"""
-                        SELECT *
-                        FROM {table}
-                        WHERE `id` = :id_
-                        """
-                    ), parameters={"id_": int(task_inputs[table])}
-                )
-                for column, value in next(rows.mappings()).items():
-                    # Because of string replacement, the value needs to be a string
-                    # can not easily rectify without first converting the XML to JSON
-                    fetched_data[f"{table}.{column}"] = str(value)
-            line = line.replace(match.group(), fetched_data[field])
-        line = line.replace("[TASK:id]", str(task.task_id))
-        line = line.replace("[CONSTANT:base_url]", "get_the_right_base_url")
-        lines.append(line)
-    return '\n'.join(lines)
+    """  # noqa: E501
+    json_template = convert_template_xml_to_json(template)
+    return _fill_json_template(
+        json_template,
+        task,
+        task_inputs,
+        fetched_data={},
+        connection=connection,
+    )
+
+
+def _fill_json_template(
+    template: dict[str, Any],
+    task: RowMapping,
+    task_inputs: dict[str, str],
+    fetched_data: dict[str, Any],
+    connection: Connection,
+) -> dict[str, Any] | list[dict[str, Any]] | str:
+    if isinstance(template, dict):
+        return {
+            k: _fill_json_template(v, task, task_inputs, fetched_data, connection)
+            for k, v in template.items()
+        }
+    if isinstance(template, list):
+        return [
+            _fill_json_template(v, task, task_inputs, fetched_data, connection) for v in template
+        ]
+    if not isinstance(template, str):
+        msg = f"Unexpected type for `template`: {template=}, {type(template)=}"
+        raise TypeError(msg)
+
+    # I believe at this point, if there is an [INPUT:] or [LOOKUP:] directive,
+    # this is always the entirety of the string. However, for now we verify explicitly.
+    if match := re.search(r"\[INPUT:(.*)]", template):
+        (field,) = match.groups()
+        if match.string == template:
+            # How do we know the default value? probably ttype_io table?
+            return task_inputs.get(field, [])
+        template = template.replace(match.group(), task_inputs[field])
+    if match := re.search(r"\[LOOKUP:(.*)]", template):
+        (field,) = match.groups()
+        if field not in fetched_data:
+            table, _ = field.split(".")
+            rows = connection.execute(
+                text(
+                    f"""
+                    SELECT *
+                    FROM {table}
+                    WHERE `id` = :id_
+                    """,  # nosec
+                ),
+                # Not sure how parametrize table names, as the parametrization adds
+                # quotes which is not legal.
+                parameters={"id_": int(task_inputs[table])},
+            )
+            for column, value in next(rows.mappings()).items():
+                fetched_data[f"{table}.{column}"] = value
+        if match.string == template:
+            return fetched_data[field]
+        template = template.replace(match.group(), fetched_data[field])
+    # I believe that the operations below are always part of string output, so
+    # we don't need to be careful to avoid losing typedness
+    template = template.replace("[TASK:id]", str(task.task_id))
+    return template.replace("[CONSTANT:base_url]", "https://test.openml.org/")
 
 
 @router.get("/{task_id}")
 def get_task(
     task_id: int,
-    user: Annotated[User | None, Depends(fetch_user)] = None,
+    # user: Annotated[User | None, Depends(fetch_user)] = None,  #  Privacy is not respected
     expdb: Annotated[Connection, Depends(expdb_connection)] = None,
 ) -> Task:
     # fetch primary task metadata
@@ -116,19 +153,21 @@ def get_task(
             SELECT *
             FROM task
             WHERE `task_id` = :task_id
-            """
-        ), parameters={"task_id": task_id}
+            """,
+        ),
+        parameters={"task_id": task_id},
     )
     task = next(task_row.mappings())
     # fetch secondary task metadata
     task_type_row = expdb.execute(
         text(
             """
-            SELECT * 
+            SELECT *
             FROM task_type
             WHERE `ttid` = :task_type_id
-            """
-        ), parameters={"task_type_id": task.ttid}
+            """,
+        ),
+        parameters={"task_type_id": task.ttid},
     )
     task_type = next(task_type_row)
     input_rows = expdb.execute(
@@ -137,81 +176,49 @@ def get_task(
             SELECT `input`, `value`
             FROM task_inputs
             WHERE task_id = :task_id
-            """
-        ), parameters={"task_id": task_id}
+            """,
+        ),
+        parameters={"task_id": task_id},
     )
-    inputs = {row.input: row.value for row in input_rows}
+    task_inputs = {
+        row.input: int(row.value) if row.value.isdigit() else row.value for row in input_rows
+    }
     ttios = expdb.execute(
         text(
             """
             SELECT *
             FROM task_type_inout
             WHERE `ttid` = :task_type_id AND `template_api` IS NOT NULL
-            """
-        ), parameters={"task_type_id": task.ttid}
+            """,
+        ),
+        parameters={"task_type_id": task.ttid},
     )
-    # breakpoint()
     # Have a look at "hidden" requirements. Do we ignore them at this stage?
-    # templates = [
-    #     (tt_io.name, tt_io.io, tt_io.requirement, tt_io.template)
-    #     for tt_io in ttios
-    # ]
-    # inputs = [
-    #     fill_template(template, task, )
-    #     for name, io, required, template in templates
-    #     if io == "input" and (required == "required" or name in inputs)
-    # ]
-    # outputs = [
-    #     fill_template(template)
-    #     for name, io, required, template in templates
-    #     if io == "output"
-    # ]
-    fs = []
-    for tt_io in ttios:
-        if tt_io.name not in inputs and tt_io.requirement == "optional":
-            continue
-        fs.append(fill_template(
-            tt_io.template_api,
-            task,
-            inputs,
-            expdb,
-        ))
-    breakpoint()
-    # def get_task_input_output():
-    #     ttios = expdb.execute(
-    #         text(
-    #             """
-    #             SELECT *
-    #             FROM task_type_inout
-    #             WHERE `ttid` = :task_type_id AND `template_api` IS NOT NULL
-    #             """
-    #         ), parameters={"task_type_id": task.ttid}
-    #     )
-    #     for tt_io in ttios:
-    #         tt_io.template_api
-    #         {
-    #             "name": tt_io.name,
-    #             <template>
-    #         }
-    # for table, identifier in inputs.items():
-    #     ...
-    # [CONSTANT: base_url]api_splits / get / [TASK: id] / Task_[TASK:id]
-    # _splits.arff
-    # if custom_testset is part, then raise error
-    # get tasktype io
+    templates = [(tt_io.name, tt_io.io, tt_io.requirement, tt_io.template_api) for tt_io in ttios]
+    inputs = [
+        fill_template(template, task, task_inputs, expdb) | {"name": name}
+        for name, io, required, template in templates
+        if io == "input"
+    ]
+    outputs = [
+        convert_template_xml_to_json(template) | {"name": name}
+        for name, io, required, template in templates
+        if io == "output"
+    ]
     tag_rows = expdb.execute(
         text(
             """
             SELECT `tag`
             FROM task_tag
-            WHERE `id` = :task_id 
-            """
-        ), parameters={"task_id": task_id}
+            WHERE `id` = :task_id
+            """,
+        ),
+        parameters={"task_id": task_id},
     )
     tags = [row.tag for row in tag_rows]
     name = f"Task {task_id} ({task_type.name})"
-    if dataset_id := inputs.get("source_data"):
-        dataset = get_dataset(dataset_id, expdb)
+    dataset_id = task_inputs.get("source_data")
+    if dataset_id and (dataset := get_dataset(dataset_id, expdb)):
         name = f"Task {task_id}:  {dataset['name']} ({task_type.name})"
 
     return Task(
@@ -219,7 +226,7 @@ def get_task(
         name=name,
         task_type_id=task.ttid,
         task_type=task_type.name,
-        input_=[inputs],
-        output={},
+        input_=inputs,
+        output=outputs,
         tags=tags,
     )

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -219,7 +219,7 @@ def get_task(
     name = f"Task {task_id} ({task_type.name})"
     dataset_id = task_inputs.get("source_data")
     if dataset_id and (dataset := get_dataset(dataset_id, expdb)):
-        name = f"Task {task_id}:  {dataset['name']} ({task_type.name})"
+        name = f"Task {task_id}: {dataset['name']} ({task_type.name})"
 
     return Task(
         id_=task.task_id,

--- a/src/routers/openml/tasktype.py
+++ b/src/routers/openml/tasktype.py
@@ -46,7 +46,10 @@ def get_task_type(
             detail={"code": "241", "message": "Unknown task type."},
         ) from None
 
-    task_type = _normalize_task_type(task_type_record)
+    # TODO: This below now is a RowMapping instead of a dictionary.
+    # In general: rerun all integration tests to make sure everything works after some
+    # recent task changes of dict to RowMapping/CursorResult[Any] types.
+    task_type = _normalize_task_type(task_type_record._asdict())
     # Some names are quoted, or have typos in their comma-separation (e.g. 'A ,B')
     task_type["creator"] = [
         creator.strip(' "') for creator in cast(str, task_type["creator"]).split(",")
@@ -60,12 +63,12 @@ def get_task_type(
     input_types = []
     for task_type_input in task_type_inputs:
         input_ = {}
-        if task_type_input["requirement"] == "required":
-            input_["requirement"] = task_type_input["requirement"]
-        input_["name"] = task_type_input["name"]
+        if task_type_input.requirement == "required":
+            input_["requirement"] = task_type_input.requirement
+        input_["name"] = task_type_input.name
         # api_constraints is for one input only in the test database (TODO: patch db)
-        if isinstance(task_type_input["api_constraints"], str):
-            constraint = json.loads(task_type_input["api_constraints"])
+        if isinstance(task_type_input.api_constraints, str):
+            constraint = json.loads(task_type_input.api_constraints)
             input_["data_type"] = constraint["data_type"]
         input_types.append(input_)
     task_type["input"] = input_types

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -147,5 +147,5 @@ class Task(BaseModel):
     task_type_id: int = Field(json_schema_extra={"example": 1})
     task_type: str = Field(json_schema_extra={"example": "Supervised Classification"})
     input_: list[dict[str, Any]] = Field(serialization_alias="input")
-    output: dict[str, Any]
+    output: list[dict[str, Any]]
     tags: list[str] = Field(default_factory=list)

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -143,7 +143,9 @@ class DatasetMetadata(BaseModel):
 
 class Task(BaseModel):
     id_: int = Field(serialization_alias="id", json_schema_extra={"example": 59})
-    name: str = Field(json_schema_extra={"example": "Task 59:  mfeat-pixel (Supervised Classification)"})
+    name: str = Field(
+        json_schema_extra={"example": "Task 59:  mfeat-pixel (Supervised Classification)"},
+    )
     task_type_id: int = Field(json_schema_extra={"example": 1})
     task_type: str = Field(json_schema_extra={"example": "Supervised Classification"})
     input_: list[dict[str, Any]] = Field(serialization_alias="input")

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -138,3 +139,13 @@ class DatasetMetadata(BaseModel):
         json_schema_extra={"example": "https://www.openml.org/d/2"},
     )
     md5_checksum: str = Field(json_schema_extra={"example": "d01f6ccd68c88b749b20bbe897de3713"})
+
+
+class Task(BaseModel):
+    id_: int = Field(serialization_alias="id", json_schema_extra={"example": 59})
+    name: str = Field(json_schema_extra={"example": "Task 59:  mfeat-pixel (Supervised Classification)"})
+    task_type_id: int = Field(json_schema_extra={"example": 1})
+    task_type: str = Field(json_schema_extra={"example": "Supervised Classification"})
+    input_: list[dict[str, Any]] = Field(serialization_alias="input")
+    output: dict[str, Any]
+    tags: list[str] = Field(default_factory=list)

--- a/tests/routers/openml/migration/tasks_migration_test.py
+++ b/tests/routers/openml/migration/tasks_migration_test.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+import deepdiff
+import httpx
+import pytest
+from starlette.testclient import TestClient
+
+
+def nested_remove_nones(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {
+            key: nested_remove_nones(val)
+            for key, val in obj.items()
+            if val is not None and nested_remove_nones(val) is not None
+        }
+    if isinstance(obj, list):
+        return [nested_remove_nones(val) for val in obj if nested_remove_nones(val) is not None]
+    return obj
+
+
+def nested_int_to_str(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {key: nested_int_to_str(val) for key, val in obj.items()}
+    if isinstance(obj, list):
+        return [nested_int_to_str(val) for val in obj]
+    if isinstance(obj, int):
+        return str(obj)
+    return obj
+
+
+def nested_remove_single_element_list(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {key: nested_remove_single_element_list(val) for key, val in obj.items()}
+    if isinstance(obj, list):
+        if len(obj) == 1:
+            return nested_remove_single_element_list(obj[0])
+        return [nested_remove_single_element_list(val) for val in obj]
+    return obj
+
+
+@pytest.mark.parametrize(
+    "task_id",
+    range(1, 1306),
+)
+def test_get_task_equal(task_id: int, py_api: TestClient, php_api: httpx.Client) -> None:
+    response = py_api.get(f"/tasks/{task_id}")
+    assert response.status_code == httpx.codes.OK
+    php_response = php_api.get(f"/task/{task_id}")
+    assert php_response.status_code == httpx.codes.OK
+
+    new_json = response.json()
+    # Some fields are renamed (old = tag, new = tags)
+    new_json["tag"] = new_json.pop("tags")
+    new_json["task_id"] = new_json.pop("id")
+    new_json["task_name"] = new_json.pop("name")
+    # PHP is not typed *and* automatically removes None values
+    new_json = nested_remove_nones(new_json)
+    new_json = nested_int_to_str(new_json)
+    # It also removes "value" entries for parameters if the list is empty,
+    # it does not remove *all* empty lists, e.g., for cost_matrix input they are kept
+    estimation_procedure = next(
+        v["estimation_procedure"] for v in new_json["input"] if "estimation_procedure" in v
+    )
+    if "parameter" in estimation_procedure:
+        estimation_procedure["parameter"] = [
+            {k: v for k, v in parameter.items() if v != []}
+            for parameter in estimation_procedure["parameter"]
+        ]
+    # Fields that may return in a list now always return a list
+    new_json = nested_remove_single_element_list(new_json)
+    # Tags are not returned if they are an empty list:
+    if new_json["tag"] == []:
+        new_json.pop("tag")
+
+    # The response is no longer nested
+    new_json = {"task": new_json}
+
+    differences = deepdiff.diff.DeepDiff(
+        new_json,
+        php_response.json(),
+        ignore_order=True,
+    )
+    assert not differences

--- a/tests/routers/openml/migration/tasks_migration_test.py
+++ b/tests/routers/openml/migration/tasks_migration_test.py
@@ -38,6 +38,7 @@ def nested_remove_single_element_list(obj: Any) -> Any:
     return obj
 
 
+@pytest.mark.php()
 @pytest.mark.parametrize(
     "task_id",
     range(1, 1306),

--- a/tests/routers/openml/task_test.py
+++ b/tests/routers/openml/task_test.py
@@ -1,5 +1,6 @@
 import http.client
 
+import deepdiff
 from starlette.testclient import TestClient
 
 
@@ -21,7 +22,7 @@ def test_get_task(py_api: TestClient) -> None:
                     "data_splits_url": "https://test.openml.org/api_splits/get/59/Task_59_splits.arff",
                     "parameter": [
                         {"name": "number_repeats", "value": 1},
-                        {"name": "number_folds"},
+                        {"name": "number_folds", "value": None},
                         {"name": "percentage", "value": 33},
                         {"name": "stratified_sampling", "value": "true"},
                     ],
@@ -30,18 +31,22 @@ def test_get_task(py_api: TestClient) -> None:
             {"name": "cost_matrix", "cost_matrix": []},
             {"name": "evaluation_measures", "evaluation_measures": {"evaluation_measure": []}},
         ],
-        "output": {
-            "name": "predictions",
-            "predictions": {
-                "format": "ARFF",
-                "feature": [
-                    {"name": "repeat", "type": "integer"},
-                    {"name": "fold", "type": "integer"},
-                    {"name": "row_id", "type": "integer"},
-                    {"name": "confidence.classname", "type": "numeric"},
-                    {"name": "prediction", "type": "string"},
-                ],
+        "output": [
+            {
+                "name": "predictions",
+                "predictions": {
+                    "format": "ARFF",
+                    "feature": [
+                        {"name": "repeat", "type": "integer"},
+                        {"name": "fold", "type": "integer"},
+                        {"name": "row_id", "type": "integer"},
+                        {"name": "confidence.classname", "type": "numeric"},
+                        {"name": "prediction", "type": "string"},
+                    ],
+                },
             },
-        },
+        ],
+        "tags": [],  # Not in PHP
     }
-    assert response.json() == expected
+    differences = deepdiff.diff.DeepDiff(response.json(), expected, ignore_order=True)
+    assert not differences

--- a/tests/routers/openml/task_test.py
+++ b/tests/routers/openml/task_test.py
@@ -1,0 +1,8 @@
+import http.client
+
+from starlette.testclient import TestClient
+
+
+def test_get_task(py_api: TestClient) -> None:
+    response = py_api.get("/tasks/59")
+    assert response.status_code == http.client.OK

--- a/tests/routers/openml/task_test.py
+++ b/tests/routers/openml/task_test.py
@@ -6,3 +6,42 @@ from starlette.testclient import TestClient
 def test_get_task(py_api: TestClient) -> None:
     response = py_api.get("/tasks/59")
     assert response.status_code == http.client.OK
+    expected = {
+        "id": 59,
+        "name": "Task 59:  mfeat-pixel (Supervised Classification)",
+        "task_type_id": 1,
+        "task_type": "Supervised Classification",
+        "input": [
+            {"name": "source_data", "data_set": {"data_set_id": 10, "target_feature": "class"}},
+            {
+                "name": "estimation_procedure",
+                "estimation_procedure": {
+                    "id": 5,
+                    "type": "holdout",
+                    "data_splits_url": "https://test.openml.org/api_splits/get/59/Task_59_splits.arff",
+                    "parameter": [
+                        {"name": "number_repeats", "value": 1},
+                        {"name": "number_folds"},
+                        {"name": "percentage", "value": 33},
+                        {"name": "stratified_sampling", "value": "true"},
+                    ],
+                },
+            },
+            {"name": "cost_matrix", "cost_matrix": []},
+            {"name": "evaluation_measures", "evaluation_measures": {"evaluation_measure": []}},
+        ],
+        "output": {
+            "name": "predictions",
+            "predictions": {
+                "format": "ARFF",
+                "feature": [
+                    {"name": "repeat", "type": "integer"},
+                    {"name": "fold", "type": "integer"},
+                    {"name": "row_id", "type": "integer"},
+                    {"name": "confidence.classname", "type": "numeric"},
+                    {"name": "prediction", "type": "string"},
+                ],
+            },
+        },
+    }
+    assert response.json() == expected

--- a/tests/routers/openml/task_test.py
+++ b/tests/routers/openml/task_test.py
@@ -9,7 +9,7 @@ def test_get_task(py_api: TestClient) -> None:
     assert response.status_code == http.client.OK
     expected = {
         "id": 59,
-        "name": "Task 59:  mfeat-pixel (Supervised Classification)",
+        "name": "Task 59: mfeat-pixel (Supervised Classification)",
         "task_type_id": 1,
         "task_type": "Supervised Classification",
         "input": [


### PR DESCRIPTION
Adds the get task endpoint, with a few caveats:

  - There are a few things unclear (see #22)
  - The template parsing and filling should be moved outside of the router module.
  - Introduces a few very similar functions to `datasets/tasks.py` which I should unify.