### PR TITLE
Fix subflow type annotation, which was wrong

### DIFF
--- a/src/schemas/flows.py
+++ b/src/schemas/flows.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime
-from typing import Any, Self
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -23,7 +25,12 @@ class Flow(BaseModel):
     language: str | None = Field(max_length=128)
     dependencies: str | None
     parameter: list[Parameter]
-    subflows: list[Self]
+    subflows: list[Subflow]
     tag: list[str]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class Subflow(TypedDict):
+    identifier: str | None
+    flow: Flow


### PR DESCRIPTION
it wasn't caught in older versions of pydantic because (I think) the Self keyword was not supported yet.