### PR TITLE
Remove black and bandit from pre-commit in favor of ruff

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
           docker compose build python-api
           docker compose up -d --wait python-api php-api
       - run: docker container ls && docker image ls
+      - run: docker exec python-api python -m pip freeze
       - run: docker exec python-api python -m pytest -xv -m "php_api"
   python:
     runs-on: ubuntu-latest
@@ -36,4 +37,5 @@ jobs:
           python-version: 3.x
       - run: docker compose up -d --wait database python-api
       - run: docker container ls && docker image ls
+      - run: docker exec python-api python -m pip freeze
       - run: docker exec python-api python -m pytest -xv -m "not php_api"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,6 @@ jobs:
           docker compose build python-api
           docker compose up -d --wait python-api php-api
       - run: docker container ls && docker image ls
-      - run: docker exec python-api python -m pip freeze
       - run: docker exec python-api python -m pytest -xv -m "php_api"
   python:
     runs-on: ubuntu-latest
@@ -37,5 +36,4 @@ jobs:
           python-version: 3.x
       - run: docker compose up -d --wait database python-api
       - run: docker container ls && docker image ls
-      - run: docker exec python-api python -m pip freeze
       - run: docker exec python-api python -m pytest -xv -m "not php_api"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,8 +37,4 @@ repos:
     hooks:
     -   id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
--   repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-    -   id: black
+    -   id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,6 @@ repos:
 # Uncomment line below after first demo
 #    -   id: no-commit-to-branch
 
--   repo: https://github.com/PyCQA/bandit
-    rev: '1.7.10'
-    hooks:
-    - id: bandit
-      args: [-c, pyproject.toml]
-
-
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v1.11.2'
     hooks:
@@ -36,5 +29,5 @@ repos:
     rev: 'v0.6.7'
     hooks:
     -   id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix]
     -   id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ docs = [
 skips = ["./tests/*"]
 
 [tool.ruff]
-select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "SIM"]
+lint.select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "SIM"]
 line-length = 100
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ skips = ["./tests/*"]
 line-length = 100
 
 [tool.ruff.lint]
-select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "S","SIM"]
+select = ["A", "ARG", "B", "COM", "C4", "C90", "E", "EM", "F", "I", "N", "PT", "PTH", "T20", "RET", "S","SIM","W"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,12 @@ skips = ["./tests/*"]
 line-length = 100
 
 [tool.ruff.lint]
-select = ["A", "ARG", "B", "COM", "C4", "C90", "E", "EM", "F", "I", "N", "PT", "PTH", "T20", "RET", "S","SIM","W"]
+# The D doc class is current heavily violated
+select = ["A", "ARG", "B", "COM", "C4", "C90","E", "EM", "F", "I", "N", "PT", "PTH", "T20", "UP","RET", "S","SIM","W"]
+ignore = ["D203", "D204", "D213"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101"]
+"tests/*" = ["S101", "COM812", "D"]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,13 @@ docs = [
 skips = ["./tests/*"]
 
 [tool.ruff]
-lint.select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "SIM"]
 line-length = 100
+
+[tool.ruff.lint]
+select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "S","SIM"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,9 @@ skips = ["./tests/*"]
 line-length = 100
 
 [tool.ruff.lint]
-# The D doc class is current heavily violated
-select = ["A", "ANN", "ARG", "B", "COM", "C4", "C90","E", "EM", "F", "I", "N", "PT", "PTH", "T20", "UP","RET", "S","SIM","W", "YTT"]
-ignore = ["ANN101", "ANN102", "D203", "D204", "D213"]
+# The D doc class is current heavily violated, DTZ
+select = ["A", "ANN", "ARG", "ASYNC", "B", "BLE", "COM", "C4", "C90","DJ","E", "EM", "EXE","F", "FA","FBT", "G","I", "ISC","ICN","INP","LOG","N", "PT", "PIE", "PTH", "PYI","Q","T20", "UP","RET","RSE", "S","SIM","SLF","SLOT","T10","W", "YTT"]
+ignore = ["ANN101", "ANN102", "D203", "D204", "D213", "CPY", "D"]
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,19 @@ line-length = 100
 [tool.ruff.lint]
 # The D (doc) and DTZ (datetime zone) lint classes current heavily violated - fix later
 select = ["ALL"]
-ignore = ["ANN101", "ANN102", "CPY", "D","D203", "D204", "D213", "DTZ"]
+ignore = [
+    "ANN101",  # style choice - no annotation for self
+    "ANN102",  # style choice - no annotation for cls
+    "CPY",  # we do not require copyright in every file
+    "D",  # todo: docstring linting
+    "D203",
+    "D204",
+    "D213",
+    "DTZ", # To add
+    # Linter does not detect when types are used for Pydantic
+    "TCH001",
+    "TCH003",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [ "S101", "COM812", "D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ docs = [
 [tool.bandit.assert_used]
 skips = ["./tests/*"]
 
-[tool.black]
-line-length = 100
-
 [tool.ruff]
 select = ["A", "ARG", "B", "COM", "C4", "E", "EM", "F", "I001", "PT", "PTH", "T20", "RET", "SIM"]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,12 +48,13 @@ line-length = 100
 
 [tool.ruff.lint]
 # The D doc class is current heavily violated
-select = ["A", "ARG", "B", "COM", "C4", "C90","E", "EM", "F", "I", "N", "PT", "PTH", "T20", "UP","RET", "S","SIM","W"]
-ignore = ["D203", "D204", "D213"]
+select = ["A", "ANN", "ARG", "B", "COM", "C4", "C90","E", "EM", "F", "I", "N", "PT", "PTH", "T20", "UP","RET", "S","SIM","W", "YTT"]
+ignore = ["ANN101", "ANN102", "D203", "D204", "D213"]
+
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["S101", "COM812", "D"]
-
+"tests/*" = [ "S101", "COM812", "D"]
+"src/core/conversions.py" = ["ANN401"]
 [tool.mypy]
 strict = true
 plugins = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ line-length = 100
 
 [tool.ruff.lint]
 # The D doc class is current heavily violated, DTZ
-select = ["A", "ANN", "ARG", "ASYNC", "B", "BLE", "COM", "C4", "C90","DJ","E", "EM", "EXE","F", "FA","FBT", "G","I", "ISC","ICN","INP","LOG","N", "PT", "PIE", "PTH", "PYI","Q","T20", "UP","RET","RSE", "S","SIM","SLF","SLOT","T10","W", "YTT"]
-ignore = ["ANN101", "ANN102", "D203", "D204", "D213", "CPY", "D"]
+select = ["ALL"]
+ignore = ["ANN101", "ANN102", "D203", "D204", "D213", "CPY", "D", "DTZ"]
 
 
 [tool.ruff.lint.per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,14 +47,14 @@ skips = ["./tests/*"]
 line-length = 100
 
 [tool.ruff.lint]
-# The D doc class is current heavily violated, DTZ
+# The D (doc) and DTZ (datetime zone) lint classes current heavily violated - fix later
 select = ["ALL"]
-ignore = ["ANN101", "ANN102", "D203", "D204", "D213", "CPY", "D", "DTZ"]
-
+ignore = ["ANN101", "ANN102", "CPY", "D","D203", "D204", "D213", "DTZ"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [ "S101", "COM812", "D"]
 "src/core/conversions.py" = ["ANN401"]
+
 [tool.mypy]
 strict = true
 plugins = [

--- a/src/core/conversions.py
+++ b/src/core/conversions.py
@@ -30,7 +30,7 @@ def nested_num_to_str(obj: Any) -> Any:
         return {key: nested_num_to_str(val) for key, val in obj.items()}
     if isinstance(obj, list):
         return [nested_num_to_str(val) for val in obj]
-    if isinstance(obj, (int, float)):
+    if isinstance(obj, int | float):
         return str(obj)
     return obj
 

--- a/src/core/conversions.py
+++ b/src/core/conversions.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
 
@@ -14,9 +15,9 @@ def _str_to_num(string: str) -> int | float | str:
 def nested_str_to_num(obj: Any) -> Any:
     """Recursively tries to convert all strings in the object to numbers.
     For dictionaries, only the values will be converted."""
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {key: nested_str_to_num(val) for key, val in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, Iterable):
         return [nested_str_to_num(val) for val in obj]
     if isinstance(obj, str):
         return _str_to_num(obj)
@@ -26,41 +27,31 @@ def nested_str_to_num(obj: Any) -> Any:
 def nested_num_to_str(obj: Any) -> Any:
     """Recursively tries to convert all numbers in the object to strings.
     For dictionaries, only the values will be converted."""
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {key: nested_num_to_str(val) for key, val in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, Iterable):
         return [nested_num_to_str(val) for val in obj]
     if isinstance(obj, int | float):
         return str(obj)
     return obj
 
 
-def nested_int_to_str(obj: Any) -> Any:
-    if isinstance(obj, dict):
-        return {key: nested_int_to_str(val) for key, val in obj.items()}
-    if isinstance(obj, list):
-        return [nested_int_to_str(val) for val in obj]
-    if isinstance(obj, int):
-        return str(obj)
-    return obj
-
-
 def nested_remove_nones(obj: Any) -> Any:
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {
             key: nested_remove_nones(val)
             for key, val in obj.items()
             if val is not None and nested_remove_nones(val) is not None
         }
-    if isinstance(obj, list):
+    if isinstance(obj, Iterable):
         return [nested_remove_nones(val) for val in obj if nested_remove_nones(val) is not None]
     return obj
 
 
 def nested_remove_single_element_list(obj: Any) -> Any:
-    if isinstance(obj, dict):
+    if isinstance(obj, Mapping):
         return {key: nested_remove_single_element_list(val) for key, val in obj.items()}
-    if isinstance(obj, list):
+    if isinstance(obj, Sequence):
         if len(obj) == 1:
             return nested_remove_single_element_list(obj[0])
         return [nested_remove_single_element_list(val) for val in obj]

--- a/src/database/datasets.py
+++ b/src/database/datasets.py
@@ -1,4 +1,4 @@
-""" Translation from https://github.com/openml/OpenML/blob/c19c9b99568c0fabb001e639ff6724b9a754bbc9/openml_OS/models/api/v1/Api_data.php#L707"""
+"""Translation from https://github.com/openml/OpenML/blob/c19c9b99568c0fabb001e639ff6724b9a754bbc9/openml_OS/models/api/v1/Api_data.php#L707"""
 
 import datetime
 

--- a/src/database/evaluations.py
+++ b/src/database/evaluations.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy import Connection, Row, text
 

--- a/src/database/flows.py
+++ b/src/database/flows.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy import Connection, Row, text
 

--- a/src/database/qualities.py
+++ b/src/database/qualities.py
@@ -33,7 +33,7 @@ def _get_for_datasets(
         SELECT `data`, `quality`, `value`
         FROM data_quality
         WHERE `data` in ({dids}) AND `quality` IN ({qualities_filter})
-        """,  # nosec  - dids and qualities are not user-provided
+        """,  # noqa: S608 - dids and qualities are not user-provided
     )
     rows = connection.execute(qualities_query)
     qualities_by_id = defaultdict(list)

--- a/src/database/qualities.py
+++ b/src/database/qualities.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Iterable
+from collections.abc import Iterable
 
 from sqlalchemy import Connection, text
 

--- a/src/database/qualities.py
+++ b/src/database/qualities.py
@@ -20,7 +20,7 @@ def get_for_dataset(dataset_id: int, connection: Connection) -> list[Quality]:
     return [Quality(name=row.quality, value=row.value) for row in rows]
 
 
-def _get_for_datasets(
+def get_for_datasets(
     dataset_ids: Iterable[int],
     quality_names: Iterable[str],
     connection: Connection,

--- a/src/database/setup.py
+++ b/src/database/setup.py
@@ -19,14 +19,14 @@ def _create_engine(database_name: str) -> Engine:
 
 
 def user_database() -> Engine:
-    global _user_engine
+    global _user_engine  # noqa: PLW0603
     if _user_engine is None:
         _user_engine = _create_engine("openml")
     return _user_engine
 
 
 def expdb_database() -> Engine:
-    global _expdb_engine
+    global _expdb_engine  # noqa: PLW0603
     if _expdb_engine is None:
         _expdb_engine = _create_engine("expdb")
     return _expdb_engine

--- a/src/database/studies.py
+++ b/src/database/studies.py
@@ -1,6 +1,7 @@
 import re
+from collections.abc import Sequence
 from datetime import datetime
-from typing import Sequence, cast
+from typing import cast
 
 from sqlalchemy import Connection, Row, text
 

--- a/src/database/studies.py
+++ b/src/database/studies.py
@@ -163,9 +163,9 @@ def attach_tasks(
 
 
 def attach_runs(
-    study_id: int,  # noqa: ARG001
-    run_ids: list[int],  # noqa: ARG001
-    user: User,  # noqa: ARG001
-    connection: Connection,  # noqa: ARG001
+    study_id: int,
+    run_ids: list[int],
+    user: User,
+    connection: Connection,
 ) -> None:
     raise NotImplementedError

--- a/src/database/tasks.py
+++ b/src/database/tasks.py
@@ -1,4 +1,5 @@
-from typing import Sequence, cast
+from collections.abc import Sequence
+from typing import cast
 
 from sqlalchemy import Connection, Row, text
 

--- a/src/database/users.py
+++ b/src/database/users.py
@@ -40,7 +40,7 @@ def get_user_groups_for(*, user_id: int, connection: Connection) -> list[UserGro
         ),
         parameters={"user_id": user_id},
     )
-    return [UserGroup(group) for group, in row]
+    return [UserGroup(group) for (group,) in row]
 
 
 @dataclasses.dataclass

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -224,7 +224,7 @@ def list_datasets(
         "NumberOfNumericFeatures",
         "NumberOfSymbolicFeatures",
     ]
-    qualities_by_dataset = database.qualities._get_for_datasets(
+    qualities_by_dataset = database.qualities.get_for_datasets(
         dataset_ids=datasets.keys(),
         quality_names=qualities_to_show,
         connection=expdb_db,
@@ -314,7 +314,7 @@ def get_dataset_features(
 )
 def update_dataset_status(
     dataset_id: Annotated[int, Body()],
-    status: Annotated[Literal[DatasetStatus.ACTIVE] | Literal[DatasetStatus.DEACTIVATED], Body()],
+    status: Annotated[Literal[DatasetStatus.ACTIVE, DatasetStatus.DEACTIVATED], Body()],
     user: Annotated[User | None, Depends(fetch_user)],
     expdb: Annotated[Connection, Depends(expdb_connection)],
 ) -> dict[str, str | int]:

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -160,7 +160,7 @@ def list_datasets(
                 FROM data_quality
                 WHERE `quality`='{quality}' AND {value}
             )
-        """  # nosec  - `quality` is not user provided, value is filtered with regex
+        """  # noqa: S608 - `quality` is not user provided, value is filtered with regex
 
     number_instances_filter = quality_clause("NumberOfInstances", number_instances)
     number_classes_filter = quality_clause("NumberOfClasses", number_classes)
@@ -177,7 +177,7 @@ def list_datasets(
         {number_classes_filter} {number_missing_values_filter}
         AND IFNULL(cs.`status`, 'in_preparation') IN ({where_status})
         LIMIT {pagination.limit} OFFSET {pagination.offset}
-        """,  # nosec
+        """,  # noqa: S608
         # I am not sure how to do this correctly without an error from Bandit here.
         # However, the `status` input is already checked by FastAPI to be from a set
         # of given options, so no injection is possible (I think). The `current_status`

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -69,7 +69,7 @@ class DatasetStatusFilter(StrEnum):
 
 @router.post(path="/list", description="Provided for convenience, same as `GET` endpoint.")
 @router.get(path="/list")
-def list_datasets(
+def list_datasets(  # noqa: PLR0913
     pagination: Annotated[Pagination, Body(default_factory=Pagination)],
     data_name: Annotated[str | None, CasualString128] = None,
     tag: Annotated[str | None, SystemString64] = None,
@@ -404,11 +404,6 @@ def get_dataset(
     row_id_attribute = _csv_as_list(dataset.row_id_attribute, unquote_items=True)
     original_data_url = _csv_as_list(dataset.original_data_url, unquote_items=True)
     default_target_attribute = _csv_as_list(dataset.default_target_attribute, unquote_items=True)
-
-    # Not sure which properties are set by this bit:
-    # foreach( $this->xml_fields_dataset['csv'] as $field ) {
-    #   $dataset->{$field} = getcsv( $dataset->{$field} );
-    # }
 
     return DatasetMetadata(
         id=dataset.did,

--- a/src/routers/openml/estimation_procedure.py
+++ b/src/routers/openml/estimation_procedure.py
@@ -1,4 +1,5 @@
-from typing import Annotated, Iterable
+from collections.abc import Iterable
+from typing import Annotated
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import Connection

--- a/src/routers/openml/flows.py
+++ b/src/routers/openml/flows.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -22,7 +22,7 @@ def flow_exists(
     flow = database.flows.get_by_name(name=name, external_version=external_version, expdb=expdb)
     if flow is None:
         raise HTTPException(
-            status_code=http.client.NOT_FOUND,
+            status_code=HTTPStatus.NOT_FOUND,
             detail="Flow not found.",
         )
     return {"flow_id": flow.id}
@@ -32,7 +32,7 @@ def flow_exists(
 def get_flow(flow_id: int, expdb: Annotated[Connection, Depends(expdb_connection)] = None) -> Flow:
     flow = database.flows.get(flow_id, expdb)
     if not flow:
-        raise HTTPException(status_code=http.client.NOT_FOUND, detail="Flow not found")
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Flow not found")
 
     parameter_rows = database.flows.get_parameters(flow_id, expdb)
     parameters = [

--- a/src/routers/openml/qualities.py
+++ b/src/routers/openml/qualities.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -36,7 +36,7 @@ def get_qualities(
     dataset = database.datasets.get(dataset_id, expdb)
     if not dataset or not _user_has_access(dataset, user):
         raise HTTPException(
-            status_code=http.client.PRECONDITION_FAILED,
+            status_code=HTTPStatus.PRECONDITION_FAILED,
             detail={"code": DatasetError.NO_DATA_FILE, "message": "Unknown dataset"},
         ) from None
     return database.qualities.get_for_dataset(dataset_id, expdb)

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -76,7 +76,7 @@ def fill_template(
             {"name": "number_folds", "value: 10},
         ]
     }
-    """  # noqa: E501
+    """
     json_template = convert_template_xml_to_json(template)
     return _fill_json_template(
         json_template,
@@ -145,7 +145,6 @@ def _fill_json_template(
 @router.get("/{task_id}")
 def get_task(
     task_id: int,
-    # user: Annotated[User | None, Depends(fetch_user)] = None,  #  Privacy is not respected
     expdb: Annotated[Connection, Depends(expdb_connection)] = None,
 ) -> Task:
     if not (task := database.tasks.get(task_id, expdb)):

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -15,7 +15,7 @@ from schemas.datasets.openml import Task
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
-def convert_template_xml_to_json(xml_template: str) -> Any:
+def convert_template_xml_to_json(xml_template: str) -> Any:  # noqa: ANN401
     json_template = xmltodict.parse(xml_template.replace("oml:", ""))
     json_str = json.dumps(json_template)
     # To account for the differences between PHP and Python conversions:
@@ -29,7 +29,7 @@ def fill_template(
     task: RowMapping,
     task_inputs: dict[str, str],
     connection: Connection,
-) -> Any:
+) -> Any:  # noqa: ANN401
     """Fill in the XML template as used for task descriptions and return the result,
      converted to JSON.
 

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -125,7 +125,7 @@ def _fill_json_template(
                     SELECT *
                     FROM {table}
                     WHERE `id` = :id_
-                    """,  # nosec
+                    """,  # noqa: S608
                 ),
                 # Not sure how parametrize table names, as the parametrization adds
                 # quotes which is not legal.

--- a/src/routers/openml/tasks.py
+++ b/src/routers/openml/tasks.py
@@ -1,6 +1,6 @@
-import http.client
 import json
 import re
+from http import HTTPStatus
 from typing import Annotated, Any
 
 import xmltodict
@@ -148,10 +148,10 @@ def get_task(
     expdb: Annotated[Connection, Depends(expdb_connection)] = None,
 ) -> Task:
     if not (task := database.tasks.get(task_id, expdb)):
-        raise HTTPException(status_code=http.client.NOT_FOUND, detail="Task not found")
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail="Task not found")
     if not (task_type := database.tasks.get_task_type(task.ttid, expdb)):
         raise HTTPException(
-            status_code=http.client.INTERNAL_SERVER_ERROR,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail="Task type not found",
         )
 

--- a/src/routers/openml/tasktype.py
+++ b/src/routers/openml/tasktype.py
@@ -1,5 +1,5 @@
-import http.client
 import json
+from http import HTTPStatus
 from typing import Annotated, Any, Literal, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -46,7 +46,7 @@ def get_task_type(
     task_type_record = db_get_task_type(task_type_id, expdb)
     if task_type_record is None:
         raise HTTPException(
-            status_code=http.client.PRECONDITION_FAILED,
+            status_code=HTTPStatus.PRECONDITION_FAILED,
             detail={"code": "241", "message": "Unknown task type."},
         ) from None
 

--- a/src/routers/openml/tasktype.py
+++ b/src/routers/openml/tasktype.py
@@ -16,7 +16,7 @@ def _normalize_task_type(task_type: Row) -> dict[str, str | None | list[Any]]:
     # Task types may contain multi-line fields which have either \r\n or \n line endings
     ttype: dict[str, str | None | list[Any]] = {
         k: str(v).replace("\r\n", "\n").strip() if v is not None else v
-        for k, v in task_type._mapping.items()
+        for k, v in task_type._mapping.items()  # noqa: SLF001
         if k != "id"
     }
     ttype["id"] = ttype.pop("ttid")

--- a/src/schemas/datasets/dcat.py
+++ b/src/schemas/datasets/dcat.py
@@ -15,7 +15,7 @@ achieved by the exchange of descriptions of data sets among data portals.
 
 import datetime
 from abc import ABC
-from typing import Literal, Union
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -208,15 +208,13 @@ class DcatApWrapper(BaseModel):
     # instead of list[DcatAPObject], a union with all the possible values is necessary.
     # See https://stackoverflow.com/questions/58301364/pydantic-and-subclasses-of-abstract-class
     graph_: list[
-        Union[
-            DcatAPDataset,
-            DcatAPDistribution,
-            DcatLocation,
-            SpdxChecksum,
-            VCardOrganisation,
-            VCardIndividual,
-            DctPeriodOfTime,
-        ]
+        DcatAPDataset
+        | DcatAPDistribution
+        | DcatLocation
+        | SpdxChecksum
+        | VCardOrganisation
+        | VCardIndividual
+        | DctPeriodOfTime
     ] = Field(serialization_alias="@graph")
 
     model_config = {"populate_by_name": True, "extra": "forbid"}

--- a/src/schemas/datasets/mldcat_ap.py
+++ b/src/schemas/datasets/mldcat_ap.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 
 from abc import ABC
 from enum import StrEnum
-from typing import Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, Field, HttpUrl, field_serializer, model_serializer
 
-from schemas.datasets.openml import DatasetStatus, Visibility
+if TYPE_CHECKING:
+    from schemas.datasets.openml import DatasetStatus, Visibility
 
 
 class JsonLDQualifiedLiteral(BaseModel):
@@ -177,9 +178,6 @@ class Distribution(JsonLDObject):
         default_factory=list,
         serialization_alias="Distribution.accessService",
     )
-    # has_policy: Policy | None = Field(alias="hasPolicy")
-    # language: list[LinguisticSystem] = Field(default_factory=list)
-    # licence: LicenceDocument | None = Field()
 
 
 class Dataset(JsonLDObject):

--- a/src/schemas/datasets/mldcat_ap.py
+++ b/src/schemas/datasets/mldcat_ap.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 from abc import ABC
 from enum import StrEnum
-from typing import TYPE_CHECKING, Generic, Literal, TypeVar
+from typing import Generic, Literal, TypeVar
 
 from pydantic import BaseModel, Field, HttpUrl, field_serializer, model_serializer
 
-if TYPE_CHECKING:
-    from schemas.datasets.openml import DatasetStatus, Visibility
+from schemas.datasets.openml import DatasetStatus, Visibility
 
 
 class JsonLDQualifiedLiteral(BaseModel):

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -124,12 +124,6 @@ class DatasetMetadata(BaseModel):
             "description": "URL of the parquet dataset data file.",
         },
     )
-    # minio_url: HttpUrl | None = Field(
-    #     json_schema_extra={
-    #         "example": "http://openml1.win.tue.nl/dataset2/dataset_2.pq",
-    #         "description": "Deprecated, I think.",
-    #     },
-    # )
     file_id: int = Field(json_schema_extra={"example": 1})
     format_: DatasetFileFormat = Field(
         json_schema_extra={"example": DatasetFileFormat.ARFF},

--- a/src/schemas/flows.py
+++ b/src/schemas/flows.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, TypedDict
+from datetime import datetime
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
-
-if TYPE_CHECKING:
-    from datetime import datetime
 
 
 class Parameter(BaseModel):

--- a/src/schemas/flows.py
+++ b/src/schemas/flows.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class Parameter(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 import contextlib
 import json
+from collections.abc import Iterator
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Iterator, NamedTuple
+from typing import Any, NamedTuple
 
 import _pytest.mark
 import httpx

--- a/tests/routers/openml/dataset_tag_test.py
+++ b/tests/routers/openml/dataset_tag_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import pytest
 from sqlalchemy import Connection
@@ -20,7 +20,7 @@ def test_dataset_tag_rejects_unauthorized(key: ApiKey, py_api: TestClient) -> No
         f"/datasets/tag{apikey}",
         json={"data_id": next(iter(constants.PRIVATE_DATASET_ID)), "tag": "test"},
     )
-    assert response.status_code == http.client.PRECONDITION_FAILED
+    assert response.status_code == HTTPStatus.PRECONDITION_FAILED
     assert response.json()["detail"] == {"code": "103", "message": "Authentication failed"}
 
 
@@ -35,7 +35,7 @@ def test_dataset_tag(key: ApiKey, expdb_test: Connection, py_api: TestClient) ->
         f"/datasets/tag?api_key={key}",
         json={"data_id": dataset_id, "tag": tag},
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data_tag": {"id": str(dataset_id), "tag": tag}}
 
     tags = get_tags_for(id_=dataset_id, connection=expdb_test)
@@ -48,7 +48,7 @@ def test_dataset_tag_returns_existing_tags(py_api: TestClient) -> None:
         f"/datasets/tag?api_key={ApiKey.ADMIN}",
         json={"data_id": dataset_id, "tag": tag},
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == {"data_tag": {"id": str(dataset_id), "tag": ["study_14", tag]}}
 
 
@@ -58,7 +58,7 @@ def test_dataset_tag_fails_if_tag_exists(py_api: TestClient) -> None:
         f"/datasets/tag?api_key={ApiKey.ADMIN}",
         json={"data_id": dataset_id, "tag": tag},
     )
-    assert response.status_code == http.client.INTERNAL_SERVER_ERROR
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
     expected = {
         "detail": {
             "code": "473",
@@ -83,5 +83,5 @@ def test_dataset_tag_invalid_tag_is_rejected(
         json={"data_id": 1, "tag": tag},
     )
 
-    assert new.status_code == http.client.UNPROCESSABLE_ENTITY
+    assert new.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
     assert new.json()["detail"][0]["loc"] == ["body", "tag"]

--- a/tests/routers/openml/dataset_tag_test.py
+++ b/tests/routers/openml/dataset_tag_test.py
@@ -18,7 +18,7 @@ def test_dataset_tag_rejects_unauthorized(key: ApiKey, py_api: TestClient) -> No
     apikey = "" if key is None else f"?api_key={key}"
     response = py_api.post(
         f"/datasets/tag{apikey}",
-        json={"data_id": list(constants.PRIVATE_DATASET_ID)[0], "tag": "test"},
+        json={"data_id": next(iter(constants.PRIVATE_DATASET_ID)), "tag": "test"},
     )
     assert response.status_code == http.client.PRECONDITION_FAILED
     assert response.json()["detail"] == {"code": "103", "message": "Authentication failed"}
@@ -30,7 +30,7 @@ def test_dataset_tag_rejects_unauthorized(key: ApiKey, py_api: TestClient) -> No
     ids=["administrator", "non-owner", "owner"],
 )
 def test_dataset_tag(key: ApiKey, expdb_test: Connection, py_api: TestClient) -> None:
-    dataset_id, tag = list(constants.PRIVATE_DATASET_ID)[0], "test"
+    dataset_id, tag = next(iter(constants.PRIVATE_DATASET_ID)), "test"
     response = py_api.post(
         f"/datasets/tag?api_key={key}",
         json={"data_id": dataset_id, "tag": tag},

--- a/tests/routers/openml/datasets_list_datasets_test.py
+++ b/tests/routers/openml/datasets_list_datasets_test.py
@@ -154,7 +154,8 @@ def test_list_uploader(user_id: int, count: int, key: str, py_api: TestClient) -
         json={"status": "all", "uploader": user_id},
     )
     # The dataset of user 16 is private, so can not be retrieved by other users.
-    if key == ApiKey.REGULAR_USER and user_id == 16:
+    owner_user_id = 16
+    if key == ApiKey.REGULAR_USER and user_id == owner_user_id:
         _assert_empty_result(response)
         return
 

--- a/tests/routers/openml/datasets_list_datasets_test.py
+++ b/tests/routers/openml/datasets_list_datasets_test.py
@@ -247,7 +247,7 @@ def test_list_data_identical(
     py_api: TestClient,
     php_api: httpx.Client,
     **kwargs: dict[str, Any],
-) -> Any:
+) -> Any:  # noqa: ANN401
     limit, offset = kwargs["limit"], kwargs["offset"]
     if (limit and not offset) or (offset and not limit):
         # Behavior change: in new API these may be used independently, not in old.

--- a/tests/routers/openml/datasets_list_datasets_test.py
+++ b/tests/routers/openml/datasets_list_datasets_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 from typing import Any
 
 import httpx
@@ -15,13 +15,13 @@ from tests.conftest import ApiKey
 def _assert_empty_result(
     response: httpx.Response,
 ) -> None:
-    assert response.status_code == http.client.PRECONDITION_FAILED
+    assert response.status_code == HTTPStatus.PRECONDITION_FAILED
     assert response.json()["detail"] == {"code": "372", "message": "No results"}
 
 
 def test_list(py_api: TestClient) -> None:
     response = py_api.get("/datasets/list/")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert len(response.json()) >= 1
 
 
@@ -39,7 +39,7 @@ def test_list_filter_active(status: str, amount: int, py_api: TestClient) -> Non
         "/datasets/list",
         json={"status": status, "pagination": {"limit": constants.NUMBER_OF_DATASETS}},
     )
-    assert response.status_code == http.client.OK, response.json()
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert len(response.json()) == amount
 
 
@@ -58,7 +58,7 @@ def test_list_accounts_privacy(api_key: ApiKey | None, amount: int, py_api: Test
         f"/datasets/list{key}",
         json={"status": "all", "pagination": {"limit": 1000}},
     )
-    assert response.status_code == http.client.OK, response.json()
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert len(response.json()) == amount
 
 
@@ -72,7 +72,7 @@ def test_list_data_name_present(name: str, count: int, py_api: TestClient) -> No
         f"/datasets/list?api_key={ApiKey.ADMIN}",
         json={"status": "all", "data_name": name},
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     datasets = response.json()
     assert len(datasets) == count
     assert all(dataset["name"] == name for dataset in datasets)
@@ -112,7 +112,7 @@ def test_list_pagination(limit: int | None, offset: int | None, py_api: TestClie
         _assert_empty_result(response)
         return
 
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     reported_ids = {dataset["did"] for dataset in response.json()}
     assert reported_ids == set(expected_ids)
 
@@ -126,7 +126,7 @@ def test_list_data_version(version: int, count: int, py_api: TestClient) -> None
         f"/datasets/list?api_key={ApiKey.ADMIN}",
         json={"status": "all", "data_version": version},
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     datasets = response.json()
     assert len(datasets) == count
     assert {dataset["version"] for dataset in datasets} == {version}
@@ -159,7 +159,7 @@ def test_list_uploader(user_id: int, count: int, key: str, py_api: TestClient) -
         _assert_empty_result(response)
         return
 
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert len(response.json()) == count
 
 
@@ -173,7 +173,7 @@ def test_list_data_id(data_id: list[int], py_api: TestClient) -> None:
         json={"status": "all", "data_id": data_id},
     )
 
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     private_or_not_exist = {130, 3000}
     assert len(response.json()) == len(set(data_id) - private_or_not_exist)
 
@@ -189,7 +189,7 @@ def test_list_data_tag(tag: str, count: int, py_api: TestClient) -> None:
         # we don't know if the results are limited by filtering on the tag.
         json={"status": "all", "tag": tag, "pagination": {"limit": 101}},
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert len(response.json()) == count
 
 
@@ -219,7 +219,7 @@ def test_list_data_quality(quality: str, range_: str, count: int, py_api: TestCl
         "/datasets/list",
         json={"status": "all", quality: range_},
     )
-    assert response.status_code == http.client.OK, response.json()
+    assert response.status_code == HTTPStatus.OK, response.json()
     assert len(response.json()) == count
 
 
@@ -281,7 +281,7 @@ def test_list_data_identical(
     original = php_api.get(uri)
 
     assert original.status_code == response.status_code, response.json()
-    if original.status_code == http.client.PRECONDITION_FAILED:
+    if original.status_code == HTTPStatus.PRECONDITION_FAILED:
         assert original.json()["error"] == response.json()["detail"]
         return None
     new_json = response.json()

--- a/tests/routers/openml/evaluationmeasures_test.py
+++ b/tests/routers/openml/evaluationmeasures_test.py
@@ -1,11 +1,11 @@
-import http.client
+from http import HTTPStatus
 
 from starlette.testclient import TestClient
 
 
 def test_evaluationmeasure_list(py_api: TestClient) -> None:
     response = py_api.get("/evaluationmeasure/list")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == [
         "area_under_roc_curve",
         "average_cost",
@@ -83,7 +83,7 @@ def test_evaluationmeasure_list(py_api: TestClient) -> None:
 
 def test_estimation_procedure_list(py_api: TestClient) -> None:
     response = py_api.get("/estimationprocedure/list")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == [
         {
             "id": 1,

--- a/tests/routers/openml/flows_test.py
+++ b/tests/routers/openml/flows_test.py
@@ -277,7 +277,7 @@ def test_get_flow_with_subflow(py_api: TestClient) -> None:
                             "data_type": "flag",
                             "default_value": None,
                             "description": (
-                                "Do not use MDL correction for info" " gain on numeric attributes."
+                                "Do not use MDL correction for info gain on numeric attributes."
                             ),
                         },
                         {

--- a/tests/routers/openml/flows_test.py
+++ b/tests/routers/openml/flows_test.py
@@ -73,7 +73,7 @@ def test_flow_exists_not_exists(py_api: TestClient) -> None:
 
 def test_get_flow_no_subflow(py_api: TestClient) -> None:
     response = py_api.get("/flows/1")
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
     expected = {
         "id": 1,
         "uploader": 16,
@@ -120,7 +120,7 @@ def test_get_flow_no_subflow(py_api: TestClient) -> None:
 
 def test_get_flow_with_subflow(py_api: TestClient) -> None:
     response = py_api.get("/flows/3")
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
     expected = {
         "id": 3,
         "uploader": 16,

--- a/tests/routers/openml/flows_test.py
+++ b/tests/routers/openml/flows_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import deepdiff.diff
 import pytest
@@ -55,25 +55,25 @@ def test_flow_exists_handles_flow_not_found(mocker: MockerFixture, expdb_test: C
     mocker.patch("database.flows.get_by_name", return_value=None)
     with pytest.raises(HTTPException) as error:
         flow_exists("foo", "bar", expdb_test)
-    assert error.value.status_code == http.client.NOT_FOUND
+    assert error.value.status_code == HTTPStatus.NOT_FOUND
     assert error.value.detail == "Flow not found."
 
 
 def test_flow_exists(flow: Flow, py_api: TestClient) -> None:
     response = py_api.get(f"/flows/exists/{flow.name}/{flow.external_version}")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == {"flow_id": flow.id}
 
 
 def test_flow_exists_not_exists(py_api: TestClient) -> None:
     response = py_api.get("/flows/exists/foo/bar")
-    assert response.status_code == http.client.NOT_FOUND
+    assert response.status_code == HTTPStatus.NOT_FOUND
     assert response.json()["detail"] == "Flow not found."
 
 
 def test_get_flow_no_subflow(py_api: TestClient) -> None:
     response = py_api.get("/flows/1")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "id": 1,
         "uploader": 16,
@@ -120,7 +120,7 @@ def test_get_flow_no_subflow(py_api: TestClient) -> None:
 
 def test_get_flow_with_subflow(py_api: TestClient) -> None:
     response = py_api.get("/flows/3")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "id": 3,
         "uploader": 16,

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -137,7 +137,7 @@ def test_private_dataset_admin_access(py_api: TestClient) -> None:
 
 @pytest.mark.parametrize(
     "dataset_id",
-    [*list(range(1, 10)), 101],
+    [*range(1, 10), 101],
 )
 @pytest.mark.parametrize(
     "api_key",

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -13,7 +13,7 @@ from tests.conftest import ApiKey
     "dataset_id",
     range(1, 132),
 )
-def test_dataset_response_is_identical(
+def test_dataset_response_is_identical(  # noqa: C901
     dataset_id: int,
     py_api: TestClient,
     php_api: httpx.Client,

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -13,7 +13,7 @@ from tests.conftest import ApiKey
     "dataset_id",
     range(1, 132),
 )
-def test_dataset_response_is_identical(  # noqa: C901
+def test_dataset_response_is_identical(  # noqa: C901, PLR0912
     dataset_id: int,
     py_api: TestClient,
     php_api: httpx.Client,
@@ -137,7 +137,7 @@ def test_private_dataset_admin_access(py_api: TestClient) -> None:
 
 @pytest.mark.parametrize(
     "dataset_id",
-    list(range(1, 10)) + [101],
+    [*list(range(1, 10)), 101],
 )
 @pytest.mark.parametrize(
     "api_key",

--- a/tests/routers/openml/migration/flows_migration_test.py
+++ b/tests/routers/openml/migration/flows_migration_test.py
@@ -53,7 +53,7 @@ def test_flow_exists(
 )
 def test_get_flow_equal(flow_id: int, py_api: TestClient, php_api: httpx.Client) -> None:
     response = py_api.get(f"/flows/{flow_id}")
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
 
     new = response.json()
 

--- a/tests/routers/openml/migration/flows_migration_test.py
+++ b/tests/routers/openml/migration/flows_migration_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 from typing import Any
 
 import deepdiff
@@ -22,8 +22,8 @@ def test_flow_exists_not(
     py_response = py_api.get(f"/flows/{path}")
     php_response = php_api.get(f"/flow/{path}")
 
-    assert py_response.status_code == http.client.NOT_FOUND
-    assert php_response.status_code == http.client.OK
+    assert py_response.status_code == HTTPStatus.NOT_FOUND
+    assert php_response.status_code == HTTPStatus.OK
 
     expect_php = {"flow_exists": {"exists": "false", "id": str(-1)}}
     assert php_response.json() == expect_php
@@ -53,7 +53,7 @@ def test_flow_exists(
 )
 def test_get_flow_equal(flow_id: int, py_api: TestClient, php_api: httpx.Client) -> None:
     response = py_api.get(f"/flows/{flow_id}")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
 
     new = response.json()
 

--- a/tests/routers/openml/migration/tasks_migration_test.py
+++ b/tests/routers/openml/migration/tasks_migration_test.py
@@ -4,7 +4,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from core.conversions import (
-    nested_int_to_str,
+    nested_num_to_str,
     nested_remove_nones,
     nested_remove_single_element_list,
 )
@@ -27,7 +27,7 @@ def test_get_task_equal(task_id: int, py_api: TestClient, php_api: httpx.Client)
     new_json["task_name"] = new_json.pop("name")
     # PHP is not typed *and* automatically removes None values
     new_json = nested_remove_nones(new_json)
-    new_json = nested_int_to_str(new_json)
+    new_json = nested_num_to_str(new_json)
     # It also removes "value" entries for parameters if the list is empty,
     # it does not remove *all* empty lists, e.g., for cost_matrix input they are kept
     estimation_procedure = next(

--- a/tests/routers/openml/migration/tasks_migration_test.py
+++ b/tests/routers/openml/migration/tasks_migration_test.py
@@ -1,3 +1,5 @@
+import http.client
+
 import deepdiff
 import httpx
 import pytest
@@ -16,9 +18,9 @@ from core.conversions import (
 )
 def test_get_task_equal(task_id: int, py_api: TestClient, php_api: httpx.Client) -> None:
     response = py_api.get(f"/tasks/{task_id}")
-    assert response.status_code == httpx.codes.OK
+    assert response.status_code == http.client.OK
     php_response = php_api.get(f"/task/{task_id}")
-    assert php_response.status_code == httpx.codes.OK
+    assert php_response.status_code == http.client.OK
 
     new_json = response.json()
     # Some fields are renamed (old = tag, new = tags)

--- a/tests/routers/openml/migration/tasks_migration_test.py
+++ b/tests/routers/openml/migration/tasks_migration_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import deepdiff
 import httpx
@@ -18,9 +18,9 @@ from core.conversions import (
 )
 def test_get_task_equal(task_id: int, py_api: TestClient, php_api: httpx.Client) -> None:
     response = py_api.get(f"/tasks/{task_id}")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     php_response = php_api.get(f"/task/{task_id}")
-    assert php_response.status_code == http.client.OK
+    assert php_response.status_code == HTTPStatus.OK
 
     new_json = response.json()
     # Some fields are renamed (old = tag, new = tags)

--- a/tests/routers/openml/qualities_test.py
+++ b/tests/routers/openml/qualities_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import deepdiff
 import httpx
@@ -38,7 +38,7 @@ def test_list_qualities_identical(py_api: TestClient, php_api: httpx.Client) -> 
 
 def test_list_qualities(py_api: TestClient, expdb_test: Connection) -> None:
     response = py_api.get("/datasets/qualities/list")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "data_qualities_list": {
             "quality": [
@@ -158,13 +158,13 @@ def test_list_qualities(py_api: TestClient, expdb_test: Connection) -> None:
     _remove_quality_from_database(quality_name=deleted, expdb_test=expdb_test)
 
     response = py_api.get("/datasets/qualities/list")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert expected == response.json()
 
 
 def test_get_quality(py_api: TestClient) -> None:
     response = py_api.get("/datasets/qualities/1")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = [
         {"name": "AutoCorrelation", "value": 0.6064659977703456},
         {"name": "CfsSubsetEval_DecisionStumpAUC", "value": 0.9067742570970945},

--- a/tests/routers/openml/study_test.py
+++ b/tests/routers/openml/study_test.py
@@ -10,7 +10,7 @@ from schemas.study import StudyType
 
 def test_get_task_study_by_id(py_api: TestClient) -> None:
     response = py_api.get("/studies/1")
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
     expected = {
         "id": 1,
         "alias": "OpenML100",
@@ -234,7 +234,7 @@ def test_get_task_study_by_id(py_api: TestClient) -> None:
 
 def test_get_task_study_by_alias(py_api: TestClient) -> None:
     response = py_api.get("/studies/OpenML100")
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
     expected = {
         "id": 1,
         "alias": "OpenML100",
@@ -468,14 +468,14 @@ def test_create_task_study(py_api: TestClient) -> None:
             "runs": [],
         },
     )
-    assert response.status_code == 200
+    assert response.status_code == http.client.OK
     new = response.json()
     assert "study_id" in new
     study_id = new["study_id"]
     assert isinstance(study_id, int)
 
     study = py_api.get(f"/studies/{study_id}")
-    assert study.status_code == 200
+    assert study.status_code == http.client.OK
     expected = {
         "id": study_id,
         "alias": "test-study",

--- a/tests/routers/openml/study_test.py
+++ b/tests/routers/openml/study_test.py
@@ -1,5 +1,5 @@
-import http.client
 from datetime import datetime
+from http import HTTPStatus
 
 import httpx
 from sqlalchemy import Connection, text
@@ -10,7 +10,7 @@ from schemas.study import StudyType
 
 def test_get_task_study_by_id(py_api: TestClient) -> None:
     response = py_api.get("/studies/1")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "id": 1,
         "alias": "OpenML100",
@@ -234,7 +234,7 @@ def test_get_task_study_by_id(py_api: TestClient) -> None:
 
 def test_get_task_study_by_alias(py_api: TestClient) -> None:
     response = py_api.get("/studies/OpenML100")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "id": 1,
         "alias": "OpenML100",
@@ -468,14 +468,14 @@ def test_create_task_study(py_api: TestClient) -> None:
             "runs": [],
         },
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     new = response.json()
     assert "study_id" in new
     study_id = new["study_id"]
     assert isinstance(study_id, int)
 
     study = py_api.get(f"/studies/{study_id}")
-    assert study.status_code == http.client.OK
+    assert study.status_code == HTTPStatus.OK
     expected = {
         "id": study_id,
         "alias": "test-study",
@@ -525,7 +525,7 @@ def test_attach_task_to_study(py_api: TestClient, expdb_test: Connection) -> Non
         py_api=py_api,
         expdb_test=expdb_test,
     )
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json() == {"study_id": 1, "main_entity_type": StudyType.TASK}
 
 
@@ -538,7 +538,7 @@ def test_attach_task_to_study_needs_owner(py_api: TestClient, expdb_test: Connec
         py_api=py_api,
         expdb_test=expdb_test,
     )
-    assert response.status_code == http.client.FORBIDDEN
+    assert response.status_code == HTTPStatus.FORBIDDEN
 
 
 def test_attach_task_to_study_already_linked_raises(
@@ -553,7 +553,7 @@ def test_attach_task_to_study_already_linked_raises(
         py_api=py_api,
         expdb_test=expdb_test,
     )
-    assert response.status_code == http.client.CONFLICT
+    assert response.status_code == HTTPStatus.CONFLICT
     assert response.json() == {"detail": "Task 1 is already attached to study 1."}
 
 
@@ -569,5 +569,5 @@ def test_attach_task_to_study_but_task_not_exist_raises(
         py_api=py_api,
         expdb_test=expdb_test,
     )
-    assert response.status_code == http.client.CONFLICT
+    assert response.status_code == HTTPStatus.CONFLICT
     assert response.json() == {"detail": "One or more of the tasks do not exist."}

--- a/tests/routers/openml/task_test.py
+++ b/tests/routers/openml/task_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import deepdiff
 from starlette.testclient import TestClient
@@ -6,7 +6,7 @@ from starlette.testclient import TestClient
 
 def test_get_task(py_api: TestClient) -> None:
     response = py_api.get("/tasks/59")
-    assert response.status_code == http.client.OK
+    assert response.status_code == HTTPStatus.OK
     expected = {
         "id": 59,
         "name": "Task 59: mfeat-pixel (Supervised Classification)",

--- a/tests/routers/openml/task_type_test.py
+++ b/tests/routers/openml/task_type_test.py
@@ -1,4 +1,4 @@
-import http.client
+from http import HTTPStatus
 
 import deepdiff.diff
 import httpx
@@ -36,5 +36,5 @@ def test_get_task_type(ttype_id: int, py_api: TestClient, php_api: httpx.Client)
 
 def test_get_task_type_unknown(py_api: TestClient) -> None:
     response = py_api.get("/tasktype/1000")
-    assert response.status_code == http.client.PRECONDITION_FAILED
+    assert response.status_code == HTTPStatus.PRECONDITION_FAILED
     assert response.json() == {"detail": {"code": "241", "message": "Unknown task type."}}


### PR DESCRIPTION
It's just fewer dependencies.
There might be small disparities between bandit and ruff, but it seems simpler to use just one tool. (and it's faster)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Replace 'black' and 'bandit' with 'ruff' in pre-commit configuration to reduce dependencies and improve performance. Enhance type handling in conversion functions and simplify union type annotations. Clean up unused code and comments, and update test cases for improved readability and compliance with linting rules.

Enhancements:
- Replace usage of 'dict' and 'list' with 'Mapping' and 'Iterable' in conversion functions for better type handling.
- Simplify union type annotations in Pydantic models using the '|' operator.
- Remove unused code and comments across various modules to improve code clarity.
- Use 'http.client.OK' instead of hardcoded status codes in test assertions for better readability.
- Refactor global variable usage in database setup functions to include 'noqa' comments for linting compliance.

Build:
- Remove 'black' and 'bandit' from pre-commit configuration in favor of using 'ruff' for linting and formatting.

Tests:
- Update test cases to use 'http.client.OK' for status code assertions.
- Modify test logic to use 'next(iter(...))' for accessing elements in sets or lists.

<!-- Generated by sourcery-ai[bot]: end summary -->