### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,12 @@ jobs:
           docker compose up -d --wait python-api php-api
       - run: docker container ls && docker image ls
       - run: docker exec python-api python -m pip freeze
-      - run: docker exec python-api python -m pytest -xv -m "php_api"
+      - run: docker exec python-api coverage run -m pytest -xv -m "php_api"
+      - run: docker exec python-api coverage xml
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
   python:
     runs-on: ubuntu-latest
     steps:
@@ -39,4 +44,9 @@ jobs:
       - run: docker compose up -d --wait database python-api
       - run: docker container ls && docker image ls
       - run: docker exec python-api python -m pip freeze
-      - run: docker exec python-api python -m pytest -xv -m "not php_api"
+      - run: docker exec python-api coverage run -m pytest -xv -m "not php_api"
+      - run: docker exec python-api coverage xml
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "coverage",
     "pre-commit",
     "pytest",
     "pytest-mock",
@@ -40,8 +41,11 @@ docs = [
 "Homepage" = "https://github.com/openml/server-api"
 "Bug Tracker" = "https://github.com/openml/server-api/issues"
 
-[tool.bandit.assert_used]
-skips = ["./tests/*"]
+[tool.coverage.run]
+branch=true
+
+[tool.coverage.report]
+show_missing=true
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
Currently not configured to be blocking, just informative. It is an explicit decision to [include coverage of test code](https://nedbatchelder.com/blog/202008/you_should_include_your_tests_in_coverage.html). 