### PR TITLE
Change/dataset/tag

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -91,6 +91,19 @@ includes datasets which are private.
 The `limit` and `offset` parameters can now be used independently, you no longer need
 to provide both if you wish to set only one.
 
+### `POST /datasets/tag`
+When successful, the "tag" property in the returned response is now always a list, even if only one tag exists for the entity.
+For example, after tagging dataset 21 with the tag `"foo"`:
+```diff
+{
+   data_tag": {
+      "id": "21",
+-      "tag": "foo"
++      "tag": ["foo"]
+   }
+}
+```
+
 ## Studies
 
 ### `GET /{id_or_alias}`

--- a/src/core/conversions.py
+++ b/src/core/conversions.py
@@ -15,18 +15,20 @@ def _str_to_num(string: str) -> int | float | str:
 def nested_str_to_num(obj: Any) -> Any:
     """Recursively tries to convert all strings in the object to numbers.
     For dictionaries, only the values will be converted."""
+    if isinstance(obj, str):
+        return _str_to_num(obj)
     if isinstance(obj, Mapping):
         return {key: nested_str_to_num(val) for key, val in obj.items()}
     if isinstance(obj, Iterable):
         return [nested_str_to_num(val) for val in obj]
-    if isinstance(obj, str):
-        return _str_to_num(obj)
     return obj
 
 
 def nested_num_to_str(obj: Any) -> Any:
     """Recursively tries to convert all numbers in the object to strings.
     For dictionaries, only the values will be converted."""
+    if isinstance(obj, str):
+        return obj
     if isinstance(obj, Mapping):
         return {key: nested_num_to_str(val) for key, val in obj.items()}
     if isinstance(obj, Iterable):
@@ -37,6 +39,8 @@ def nested_num_to_str(obj: Any) -> Any:
 
 
 def nested_remove_nones(obj: Any) -> Any:
+    if isinstance(obj, str):
+        return obj
     if isinstance(obj, Mapping):
         return {
             key: nested_remove_nones(val)
@@ -49,12 +53,12 @@ def nested_remove_nones(obj: Any) -> Any:
 
 
 def nested_remove_single_element_list(obj: Any) -> Any:
+    if isinstance(obj, str):
+        return obj
     if isinstance(obj, Mapping):
         return {key: nested_remove_single_element_list(val) for key, val in obj.items()}
     if isinstance(obj, Sequence):
         if len(obj) == 1:
             return nested_remove_single_element_list(obj[0])
-        if not obj:
-            return None
         return [nested_remove_single_element_list(val) for val in obj]
     return obj

--- a/src/core/conversions.py
+++ b/src/core/conversions.py
@@ -54,5 +54,7 @@ def nested_remove_single_element_list(obj: Any) -> Any:
     if isinstance(obj, Sequence):
         if len(obj) == 1:
             return nested_remove_single_element_list(obj[0])
+        if not obj:
+            return None
         return [nested_remove_single_element_list(val) for val in obj]
     return obj

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -48,14 +48,14 @@ def tag_dataset(
     }
 
 
-def create_authentication_failed_error():
+def create_authentication_failed_error() -> HTTPException:
     return HTTPException(
         status_code=HTTPStatus.PRECONDITION_FAILED,
         detail={"code": "103", "message": "Authentication failed"},
     )
 
 
-def create_tag_exists_error(data_id, tag):
+def create_tag_exists_error(data_id: int, tag: str) -> HTTPException:
     return HTTPException(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
         detail={

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -43,11 +43,8 @@ def tag_dataset(
         raise create_authentication_failed_error()
 
     database.datasets.tag(data_id, tag, user_id=user.user_id, connection=expdb_db)
-    all_tags = [*tags, tag]
-    tag_value = all_tags if len(all_tags) > 1 else all_tags[0]
-
     return {
-        "data_tag": {"id": str(data_id), "tag": tag_value},
+        "data_tag": {"id": str(data_id), "tag": [*tags, tag]},
     }
 
 

--- a/tests/routers/openml/dataset_tag_test.py
+++ b/tests/routers/openml/dataset_tag_test.py
@@ -36,7 +36,7 @@ def test_dataset_tag(key: ApiKey, expdb_test: Connection, py_api: TestClient) ->
         json={"data_id": dataset_id, "tag": tag},
     )
     assert response.status_code == HTTPStatus.OK
-    assert response.json() == {"data_tag": {"id": str(dataset_id), "tag": tag}}
+    assert response.json() == {"data_tag": {"id": str(dataset_id), "tag": [tag]}}
 
     tags = get_tags_for(id_=dataset_id, connection=expdb_test)
     assert tag in tags

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import httpx
 import pytest
+from core.conversions import nested_remove_single_element_list
 from starlette.testclient import TestClient
 
 from tests.conftest import ApiKey
@@ -137,7 +138,7 @@ def test_private_dataset_admin_access(py_api: TestClient) -> None:
 
 @pytest.mark.parametrize(
     "dataset_id",
-    [*range(1, 10), 101],
+    [*range(1, 10), 101, 131],
 )
 @pytest.mark.parametrize(
     "api_key",
@@ -160,17 +161,19 @@ def test_dataset_tag_response_is_identical(
         "/data/tag",
         data={"api_key": api_key, "tag": tag, "data_id": dataset_id},
     )
-    if (
-        original.status_code == HTTPStatus.PRECONDITION_FAILED
-        and original.json()["error"]["message"] == "An Elastic Search Exception occurred."
-    ):
-        pytest.skip("Encountered Elastic Search error.")
-    if original.status_code == HTTPStatus.OK:
+    already_tagged = original.status_code == HTTPStatus.INTERNAL_SERVER_ERROR and "already tagged" in original.json()["error"]["message"]
+    if not already_tagged:
         # undo the tag, because we don't want to persist this change to the database
+        # Sometimes a change is already committed to the database even if an error occurs.
         php_api.post(
             "/data/untag",
             data={"api_key": api_key, "tag": tag, "data_id": dataset_id},
         )
+    if (
+            original.status_code != HTTPStatus.OK
+            and original.json()["error"]["message"] == "An Elastic Search Exception occured."
+    ):
+        pytest.skip("Encountered Elastic Search error.")
     new = py_api.post(
         f"/datasets/tag?api_key={api_key}",
         json={"data_id": dataset_id, "tag": tag},
@@ -183,6 +186,7 @@ def test_dataset_tag_response_is_identical(
 
     original = original.json()
     new = new.json()
+    new = nested_remove_single_element_list(new)
     assert original == new
 
 

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -4,9 +4,9 @@ from typing import Any
 
 import httpx
 import pytest
-from core.conversions import nested_remove_single_element_list
 from starlette.testclient import TestClient
 
+from core.conversions import nested_remove_single_element_list
 from tests.conftest import ApiKey
 
 
@@ -161,7 +161,10 @@ def test_dataset_tag_response_is_identical(
         "/data/tag",
         data={"api_key": api_key, "tag": tag, "data_id": dataset_id},
     )
-    already_tagged = original.status_code == HTTPStatus.INTERNAL_SERVER_ERROR and "already tagged" in original.json()["error"]["message"]
+    already_tagged = (
+        original.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        and "already tagged" in original.json()["error"]["message"]
+    )
     if not already_tagged:
         # undo the tag, because we don't want to persist this change to the database
         # Sometimes a change is already committed to the database even if an error occurs.
@@ -170,8 +173,8 @@ def test_dataset_tag_response_is_identical(
             data={"api_key": api_key, "tag": tag, "data_id": dataset_id},
         )
     if (
-            original.status_code != HTTPStatus.OK
-            and original.json()["error"]["message"] == "An Elastic Search Exception occured."
+        original.status_code != HTTPStatus.OK
+        and original.json()["error"]["message"] == "An Elastic Search Exception occured."
     ):
         pytest.skip("Encountered Elastic Search error.")
     new = py_api.post(


### PR DESCRIPTION
The tag element is now always a list, regardless of the number of elements.

TODO: Update migration documentation.

## Summary by Sourcery

Ensure the tag element is always returned as a list in the dataset tagging API, refactor error handling with helper functions, and update tests to reflect these changes.

Enhancements:
- Refactor error handling by introducing helper functions for creating HTTP exceptions for authentication failure and existing tag errors.

Tests:
- Update tests to ensure that the tag element is always returned as a list, even if it contains a single element.
- Modify test cases to handle scenarios where a tag is already present, ensuring the database state is correctly managed.