### PR TITLE
Dataset/upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "mysqlclient",
     "python_dotenv",
     "xmltodict",
+    "python-multipart",
 ]
 
 [project.optional-dependencies]

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -370,6 +370,19 @@ def update_dataset_status(
     return {"dataset_id": dataset_id, "status": status}
 
 
+@router.post(
+    path="",
+)
+def upload_data(
+    user: Annotated[User | None, Depends(fetch_user)] = None,
+) -> None:
+    if user is None:
+        raise HTTPException(
+            status_code=HTTPStatus.UNAUTHORIZED,
+            detail="You need to authenticate to upload a dataset.",
+        )
+
+
 @router.get(
     path="/{dataset_id}",
     description="Get meta-data for dataset with ID `dataset_id`.",

--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -391,7 +391,7 @@ def upload_data(
     #  Spooled file-- where is it stored?
     if file.filename is None or Path(file.filename).suffix != ".pq":
         raise HTTPException(
-            status_code=HTTPStatus.IM_A_TEAPOT,
+            status_code=HTTPStatus.BAD_REQUEST,
             detail="The uploaded file needs to be a parquet file (.pq).",
         )
     #  use async interface

--- a/src/schemas/datasets/convertor.py
+++ b/src/schemas/datasets/convertor.py
@@ -6,10 +6,10 @@ from schemas.datasets.dcat import (
     SpdxChecksum,
     XSDDateTime,
 )
-from schemas.datasets.openml import DatasetMetadata
+from schemas.datasets.openml import DatasetMetadataView
 
 
-def openml_dataset_to_dcat(metadata: DatasetMetadata) -> DcatApWrapper:
+def openml_dataset_to_dcat(metadata: DatasetMetadataView) -> DcatApWrapper:
     checksum = SpdxChecksum(
         id_=metadata.md5_checksum,
         algorithm="md5",

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -62,13 +62,17 @@ class DatasetMetadata(BaseModel):
     name: str = Field(json_schema_extra={"example": "Anneal"})
     licence: str = Field(json_schema_extra={"example": "CC0"})
     version: int = Field(json_schema_extra={"example": 2})
-    version_label: str = Field(
+    version_label: str | None = Field(
         json_schema_extra={
             "example": 2,
             "description": "Not sure how this relates to `version`.",
         },
+        max_length=128,
     )
-    language: str = Field(json_schema_extra={"example": "English"})
+    language: str | None = Field(
+        json_schema_extra={"example": "English"},
+        max_length=128,
+    )
 
     creators: list[str] = Field(
         json_schema_extra={"example": ["David Sterling", "Wray Buntine"]},
@@ -78,7 +82,7 @@ class DatasetMetadata(BaseModel):
         json_schema_extra={"example": ["David Sterling", "Wray Buntine"]},
         alias="contributor",
     )
-    citation: str = Field(
+    citation: str | None = Field(
         json_schema_extra={"example": "https://archive.ics.uci.edu/ml/citation_policy.html"},
     )
     paper_url: HttpUrl | None = Field(
@@ -86,6 +90,30 @@ class DatasetMetadata(BaseModel):
             "example": "http://digital.library.adelaide.edu.au/dspace/handle/2440/15227",
         },
     )
+    collection_date: str | None = Field(json_schema_extra={"example": "1990"})
+
+    description: str = Field(
+        json_schema_extra={"example": "The original Annealing dataset from UCI."},
+    )
+    default_target_attribute: list[str] = Field(json_schema_extra={"example": "class"})
+    ignore_attribute: list[str] = Field(json_schema_extra={"example": "sensitive_feature"})
+    row_id_attribute: list[str] = Field(json_schema_extra={"example": "ssn"})
+
+    format_: DatasetFileFormat = Field(
+        json_schema_extra={"example": DatasetFileFormat.ARFF},
+        alias="format",
+    )
+    original_data_url: list[HttpUrl] | None = Field(
+        json_schema_extra={"example": "https://www.openml.org/d/2"},
+    )
+
+
+class DatasetMetadataView(DatasetMetadata):
+    id_: int = Field(json_schema_extra={"example": 1}, alias="id")
+    visibility: Visibility = Field(json_schema_extra={"example": Visibility.PUBLIC})
+    status: DatasetStatus = Field(json_schema_extra={"example": DatasetStatus.ACTIVE})
+    description_version: int = Field(json_schema_extra={"example": 2})
+    tags: list[str] = Field(json_schema_extra={"example": ["study_1", "uci"]}, alias="tag")
     upload_date: datetime = Field(
         json_schema_extra={"example": str(datetime(2014, 4, 6, 23, 12, 20))},
     )
@@ -97,17 +125,7 @@ class DatasetMetadata(BaseModel):
         alias="error",
     )
     processing_warning: str | None = Field(alias="warning")
-    collection_date: str | None = Field(json_schema_extra={"example": "1990"})
-
-    description: str = Field(
-        json_schema_extra={"example": "The original Annealing dataset from UCI."},
-    )
-    description_version: int = Field(json_schema_extra={"example": 2})
-    tags: list[str] = Field(json_schema_extra={"example": ["study_1", "uci"]}, alias="tag")
-    default_target_attribute: list[str] = Field(json_schema_extra={"example": "class"})
-    ignore_attribute: list[str] = Field(json_schema_extra={"example": "sensitive_feature"})
-    row_id_attribute: list[str] = Field(json_schema_extra={"example": "ssn"})
-
+    file_id: int = Field(json_schema_extra={"example": 1})
     url: HttpUrl = Field(
         json_schema_extra={
             "example": "https://www.openml.org/data/download/1/dataset_1_anneal.arff",
@@ -120,21 +138,7 @@ class DatasetMetadata(BaseModel):
             "description": "URL of the parquet dataset data file.",
         },
     )
-    file_id: int = Field(json_schema_extra={"example": 1})
-    format_: DatasetFileFormat = Field(
-        json_schema_extra={"example": DatasetFileFormat.ARFF},
-        alias="format",
-    )
-    original_data_url: list[HttpUrl] | None = Field(
-        json_schema_extra={"example": "https://www.openml.org/d/2"},
-    )
     md5_checksum: str = Field(json_schema_extra={"example": "d01f6ccd68c88b749b20bbe897de3713"})
-
-
-class DatasetMetadataView(DatasetMetadata):
-    id_: int = Field(json_schema_extra={"example": 1}, alias="id")
-    visibility: Visibility = Field(json_schema_extra={"example": Visibility.PUBLIC})
-    status: DatasetStatus = Field(json_schema_extra={"example": DatasetStatus.ACTIVE})
 
 
 class Task(BaseModel):

--- a/src/schemas/datasets/openml.py
+++ b/src/schemas/datasets/openml.py
@@ -59,10 +59,6 @@ class EstimationProcedure(BaseModel):
 
 
 class DatasetMetadata(BaseModel):
-    id_: int = Field(json_schema_extra={"example": 1}, alias="id")
-    visibility: Visibility = Field(json_schema_extra={"example": Visibility.PUBLIC})
-    status: DatasetStatus = Field(json_schema_extra={"example": DatasetStatus.ACTIVE})
-
     name: str = Field(json_schema_extra={"example": "Anneal"})
     licence: str = Field(json_schema_extra={"example": "CC0"})
     version: int = Field(json_schema_extra={"example": 2})
@@ -133,6 +129,12 @@ class DatasetMetadata(BaseModel):
         json_schema_extra={"example": "https://www.openml.org/d/2"},
     )
     md5_checksum: str = Field(json_schema_extra={"example": "d01f6ccd68c88b749b20bbe897de3713"})
+
+
+class DatasetMetadataView(DatasetMetadata):
+    id_: int = Field(json_schema_extra={"example": 1}, alias="id")
+    visibility: Visibility = Field(json_schema_extra={"example": Visibility.PUBLIC})
+    status: DatasetStatus = Field(json_schema_extra={"example": DatasetStatus.ACTIVE})
 
 
 class Task(BaseModel):

--- a/tests/routers/openml/datasets_test.py
+++ b/tests/routers/openml/datasets_test.py
@@ -269,3 +269,8 @@ def test_dataset_status_unauthorized(
         json={"dataset_id": dataset_id, "status": status},
     )
     assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_dataset_upload_needs_authentication(py_api: TestClient) -> None:
+    response = py_api.post("/datasets")
+    assert response.status_code == HTTPStatus.UNAUTHORIZED

--- a/tests/routers/openml/datasets_test.py
+++ b/tests/routers/openml/datasets_test.py
@@ -290,7 +290,7 @@ def test_dataset_upload_error_if_not_parquet(file_name: str) -> None:
     with pytest.raises(HTTPException) as e:
         upload_data(file=file, user=SOME_USER, metadata=None)  # type: ignore[arg-type]
 
-    assert e.value.status_code == HTTPStatus.IM_A_TEAPOT
+    assert e.value.status_code == HTTPStatus.BAD_REQUEST
     assert e.value.detail == "The uploaded file needs to be a parquet file (.pq)."
 
 

--- a/tests/routers/openml/datasets_test.py
+++ b/tests/routers/openml/datasets_test.py
@@ -8,7 +8,7 @@ from starlette.testclient import TestClient
 
 from database.users import User
 from routers.openml.datasets import get_dataset, upload_data
-from schemas.datasets.openml import DatasetMetadata, DatasetStatus
+from schemas.datasets.openml import DatasetMetadataView, DatasetStatus
 from tests.users import ADMIN_USER, NO_USER, OWNER_USER, SOME_USER, ApiKey
 
 
@@ -101,7 +101,7 @@ def test_private_dataset_access(user: User, expdb_test: Connection, user_test: C
         user_db=user_test,
         expdb_db=expdb_test,
     )
-    assert isinstance(dataset, DatasetMetadata)
+    assert isinstance(dataset, DatasetMetadataView)
 
 
 def test_dataset_features(py_api: TestClient) -> None:
@@ -274,7 +274,7 @@ def test_dataset_status_unauthorized(
 
 def test_dataset_upload_needs_authentication() -> None:
     with pytest.raises(HTTPException) as e:
-        upload_data(user=None, file=None)  # type: ignore[arg-type]
+        upload_data(user=None, file=None, metadata=None)  # type: ignore[arg-type]
 
     assert e.value.status_code == HTTPStatus.UNAUTHORIZED
     assert e.value.detail == "You need to authenticate to upload a dataset."
@@ -288,7 +288,11 @@ def test_dataset_upload_error_if_not_parquet(file_name: str) -> None:
     file = UploadFile(filename=file_name, file=BytesIO(b""))
 
     with pytest.raises(HTTPException) as e:
-        upload_data(file, SOME_USER)
+        upload_data(file=file, user=SOME_USER, metadata=None)  # type: ignore[arg-type]
 
     assert e.value.status_code == HTTPStatus.IM_A_TEAPOT
     assert e.value.detail == "The uploaded file needs to be a parquet file (.pq)."
+
+
+def test_dataset_upload() -> None:
+    pass

--- a/tests/routers/openml/datasets_test.py
+++ b/tests/routers/openml/datasets_test.py
@@ -6,7 +6,7 @@ from sqlalchemy import Connection
 from starlette.testclient import TestClient
 
 from database.users import User
-from routers.openml.datasets import get_dataset
+from routers.openml.datasets import get_dataset, upload_data
 from schemas.datasets.openml import DatasetMetadata, DatasetStatus
 from tests.users import ADMIN_USER, NO_USER, OWNER_USER, SOME_USER, ApiKey
 
@@ -271,6 +271,6 @@ def test_dataset_status_unauthorized(
     assert response.status_code == HTTPStatus.FORBIDDEN
 
 
-def test_dataset_upload_needs_authentication(py_api: TestClient) -> None:
-    response = py_api.post("/datasets")
-    assert response.status_code == HTTPStatus.UNAUTHORIZED
+def test_dataset_upload_needs_authentication() -> None:
+    with pytest.raises(HTTPException, match="You need to authenticate to upload a dataset."):
+        upload_data(user=None)

--- a/tests/routers/openml/migration/datasets_migration_test.py
+++ b/tests/routers/openml/migration/datasets_migration_test.py
@@ -1,11 +1,11 @@
 import json
 from http import HTTPStatus
 
-import constants
 import httpx
 import pytest
 from starlette.testclient import TestClient
 
+import tests.constants
 from core.conversions import nested_remove_single_element_list
 from tests.users import ApiKey
 
@@ -127,7 +127,7 @@ def test_private_dataset_owner_access(
     php_api: TestClient,
     api_key: str,
 ) -> None:
-    [private_dataset] = constants.PRIVATE_DATASET_ID
+    [private_dataset] = tests.constants.PRIVATE_DATASET_ID
     new_response = py_api.get(f"/datasets/{private_dataset}?api_key={api_key}")
     old_response = php_api.get(f"/data/{private_dataset}?api_key={api_key}")
     assert old_response.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dataset upload endpoint with parquet validation, refactor the OpenML dataset metadata into separate request and view models with additional fields, update the GET handler to return the new view model, and update tests and dependencies accordingly

New Features:
- Add POST /datasets endpoint for authenticated users to upload parquet dataset files

Enhancements:
- Split DatasetMetadata into request and view models, moving id, visibility, and status into DatasetMetadataView
- Extend metadata schema with fields for description, collection date, default target/ignore/row-id attributes, file format, and original data URLs
- Update GET /datasets/{id} to return DatasetMetadataView

Build:
- Add python-multipart dependency to support file uploads

Tests:
- Update existing dataset tests to expect DatasetMetadataView and fix import paths
- Add tests for upload endpoint authentication and parquet file validation

Chores:
- Adjust convertor and migration test imports to use the new DatasetMetadataView