### PR TITLE
Uncap Pydantic Version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 ]
 dependencies = [
     "fastapi",
-    "pydantic<2.7",
+    "pydantic",
     "uvicorn",
     "sqlalchemy",
     "mysqlclient",


### PR DESCRIPTION
I couldn't find the reason for the constraint to <2.7, local unit tests look fine with the newer version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated pydantic dependency to support newer versions, expanding compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->