### PR TITLE
Fix subflow type

### DIFF
--- a/src/schemas/flows.py
+++ b/src/schemas/flows.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Self
+from typing import Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -25,7 +25,12 @@ class Flow(BaseModel):
     language: str | None = Field(max_length=128)
     dependencies: str | None
     parameter: list[Parameter]
-    subflows: list[Self]
+    subflows: list[Subflow]
     tag: list[str]
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class Subflow(TypedDict):
+    identifier: str | None
+    flow: Flow


### PR DESCRIPTION
The `develop` branch was recently removed, and the `main` branch is now used for both development and releases (possibly via a rename from `develop` to` main`). The `develop` branch previously had an issue with the type of subflows, which caused Pydantic errors; this issue was fixed on `main`. However, that fix is no longer present on `main`. This PR restores the fix.

## Summary by Sourcery

Bug Fixes:
- Correct subflow field type on Flow to use a dedicated Subflow structure instead of self-referential Flow instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced explicit subflow type structure to improve representation and handling of nested flows within compositions.

* **Refactor**
  * Updated flow schema with explicit subflow definitions instead of self-referential types, providing clearer structure and enhanced type safety for improved maintainability across flow composition operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->