### PR TITLE
Update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,9 +163,9 @@ cython_debug/
 .idea/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 .vscode/
 


### PR DESCRIPTION
Solves #223 
Updates `.gitignore` as described in #223 in reference to the default python [`.gitignore` template](https://github.com/github/gitignore/blob/main/Python.gitignore) provided by GitHub. 