### PR TITLE
docs: correctly roll intro into single OpenML Server nav item

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,7 +15,6 @@ theme:
 nav:
   - OpenML Server: index.md
   - Getting Started: installation.md
-  - Changes: migration.md
 
   - Contributing:
       - contributing/index.md
@@ -23,6 +22,8 @@ nav:
       - Tests: contributing/tests.md
       - Documentation: contributing/documentation.md
       - Project Overview: contributing/project_overview.md
+
+  - Changes: migration.md
 
 markdown_extensions:
   - attr_list


### PR DESCRIPTION
Fixes #208

This PR updates the MkDocs navigation structure to match the intended layout discussed in the issue and PR #242.

Changes:
- Adds a single top-level "OpenML Server" nav item pointing directly to `index.md`
- Removes the separate "Intro" entry to avoid duplicate sidebar items
- Keeps "Getting Started" and "Changes" as separate sidebar items

This ensures only one "OpenML Server" item appears in the sidebar and matches the intended MkDocs Material layout.