### PR TITLE
[FIX] Correct typo which led to invalid credential

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,7 +53,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v5
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: openml/rest-api
           short-description: "Experimental OpenML REST API"
           readme-filepath: docker/python/README.md


### PR DESCRIPTION
`DOCKER_PASSWORD` is not a configured secret for this repository.