### PR TITLE
docs: add datasets untag migration note

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -111,8 +111,16 @@ For example, after tagging dataset 21 with the tag `"foo"`:
 The endpoint now enforces tag ownership when untagging:
 
  - The original tag uploader can untag their own tag.
+   Ownership is determined by matching the authenticated user ID against the
+   `uploader` field of the `dataset_tag` record.
  - Administrators can untag any tag.
  - Other authenticated users receive an error.
+
+When a non-owner/non-admin attempts to untag, the endpoint returns:
+```diff title="HTTP + JSON error for non-owner/non-admin"
+- HTTP 500 Internal Server Error
+- {"detail":{"code":"476","message":"Tag is not owned by you"}}
+```
 
 On success, the response matches legacy behavior and returns only the dataset id:
 ```json


### PR DESCRIPTION
# Description

This PR updates migration documentation for datasets by adding a dedicated `POST /datasets/untag` section.

It documents:
- ownership requirements for untagging,
- administrator override behavior,
- and the success response schema (`data_untag.id`).

Related: #6

# Checklist

_Please check all that apply. You can mark items as N/A if they don't apply to your change._

- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas, and provided or updated docstrings as needed
- [x] I have made corresponding changes to the documentation pages (`/docs`)
- [ ] I have added tests that cover the changes
- [ ] Tests pass locally.

nb. If tests pass locally but fail on CI, please try to investigate the cause. If you are unable to resolve the issue, please share your findings.