### PR TITLE
Fix tasktype api_constraints parsing for malformed JSON and dict inputs

### DIFF
--- a/src/routers/openml/tasktype.py
+++ b/src/routers/openml/tasktype.py
@@ -1,4 +1,6 @@
 import json
+import logging
+from collections.abc import Mapping
 from typing import Annotated, Any, Literal, cast
 
 from fastapi import APIRouter, Depends
@@ -11,6 +13,7 @@ from database.tasks import get_task_type as db_get_task_type
 from routers.dependencies import expdb_connection
 
 router = APIRouter(prefix="/tasktype", tags=["tasks"])
+logger = logging.getLogger(__name__)
 
 
 def _normalize_task_type(task_type: Row[Any]) -> dict[str, str | None | list[Any]]:
@@ -24,6 +27,36 @@ def _normalize_task_type(task_type: Row[Any]) -> dict[str, str | None | list[Any
     if ttype["description"] == "":
         ttype["description"] = []
     return ttype
+
+
+def _extract_data_type_from_api_constraints(
+    api_constraints: Mapping[str, Any] | str | None,
+    input_name: str,
+) -> str | None:
+    """Extract string data_type from api_constraints safely."""
+    constraint: Mapping[str, Any] | None = None
+
+    if isinstance(api_constraints, str):
+        try:
+            loaded = json.loads(api_constraints)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Failed to decode legacy api_constraints JSON for task_type_input '%s'; value=%r",
+                input_name,
+                api_constraints,
+                exc_info=True,
+            )
+            return None
+        if isinstance(loaded, Mapping):
+            constraint = loaded
+    elif isinstance(api_constraints, Mapping):
+        constraint = api_constraints
+
+    if not constraint:
+        return None
+
+    data_type = constraint.get("data_type")
+    return data_type if isinstance(data_type, str) else None
 
 
 @router.get(path="/list")
@@ -68,22 +101,12 @@ async def get_task_type(
             input_["requirement"] = task_type_input.requirement
         input_["name"] = task_type_input.name
 
-        # Accept either legacy JSON string or already parsed dict
-        constraint = None
-        ac = task_type_input.api_constraints
-        if isinstance(ac, str):
-            try:
-                constraint = json.loads(ac)
-            except json.JSONDecodeError:
-                # Keep response stable for malformed legacy values
-                constraint = None
-        elif isinstance(ac, dict):
-            constraint = ac
-
-        if isinstance(constraint, dict):
-            data_type = constraint.get("data_type")
-            if data_type is not None:
-                input_["data_type"] = data_type
+        data_type = _extract_data_type_from_api_constraints(
+            task_type_input.api_constraints,
+            task_type_input.name,
+        )
+        if data_type is not None:
+            input_["data_type"] = data_type
 
         input_types.append(input_)
 


### PR DESCRIPTION
# Description

This PR improves robustness in the `/tasktype/{task_type_id}` endpoint when processing `api_constraints`.

### What changed
In `src/routers/openml/tasktype.py`, parsing of `task_type_input.api_constraints` now:
- accepts both legacy JSON strings and already-parsed dictionaries,
- safely handles malformed JSON (`json.JSONDecodeError`) without crashing,
- only includes `data_type` in the response when it is present.

### Motivation / context
Previously, malformed legacy values or unexpected shapes in `api_constraints` could lead to unstable behavior during response construction. This change makes the endpoint defensive and stable for those cases.

Fixes: #273

# Checklist

_Please check all that apply. You can mark items as N/A if they don't apply to your change._

Always:
- [x] I have performed a self-review of my own pull request to ensure it contains all relevant information, and the proposed changes are minimal but sufficient to accomplish their task.

Required for code changes:
- [ ] Tests pass locally
- [x] I have commented my code in hard-to-understand areas, and provided or updated docstrings as needed
- [ ] Changes are already covered under existing tests
- [ ] I have added tests that cover the changes (only required if not already under coverage)

If applicable:
- [ ] I have made corresponding changes to the documentation pages (`/docs`)

Extra context:
- [ ] This PR and the commits have been created autonomously by a bot/agent.

- `ruff check .` ✅
- `ruff format .` ✅
- `pytest -k task_type` ❌ (blocked by local test DB host `openml-test-database` not available)