### PR TITLE
[FIX]  missing f-string in dataset features error message

### DIFF
--- a/src/routers/openml/datasets.py
+++ b/src/routers/openml/datasets.py
@@ -326,7 +326,7 @@ async def get_dataset_features(
             raise DatasetProcessingError(msg)
         msg = (
             "No features found. "
-            "Dataset {dataset_id} did not contain any features, or we could not extract them."
+            f"Dataset {dataset_id} did not contain any features, or we could not extract them."
         )
         raise DatasetNoFeaturesError(msg)
     return features


### PR DESCRIPTION
# Description
The error message in `get_dataset_features` was missing an f prefix on the string containing {`dataset_id}`. This caused users to see the literal text {dataset_id} instead of the actual dataset ID when a dataset had no features. Added the f prefix to correctly interpolate the variable.
