### PR TITLE
Refactor setups_tag tests to use direct method calls for non-happy-path tests

### DIFF
--- a/tests/routers/openml/setups_tag_test.py
+++ b/tests/routers/openml/setups_tag_test.py
@@ -28,7 +28,7 @@ async def test_setup_tag_api_success(
     )
 
     assert response.status_code == HTTPStatus.OK
-    expected = {'setup_tag': {'id': '1', 'tag': ['setup_tag_via_http']}}
+    expected = {"setup_tag": {"id": "1", "tag": ["setup_tag_via_http"]}}
     assert expected == response.json()
 
     rows = await expdb_test.execute(


### PR DESCRIPTION
## Summary: 
Following the testing guidelines from #295:

- Keep one happy-path test via `py_api `.
- Convert error/variation tests to direct calls to tag_setup() .
- Add a direct-call success test .