### PR TITLE
Create ES indices in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
         run: |
           services="python-api"
           if [ "${{ matrix.php_api }}" = "true" ]; then
+            sed -i 's/INDEX_ES_DURING_STARTUP=false/INDEX_ES_DURING_STARTUP=true/' docker/php/.env
             services="$services php-api"
           fi
           docker compose up $services --detach --wait --remove-orphans || exit $(docker compose ps -q | xargs docker inspect -f '{{.State.ExitCode}}' | grep -v '^0' | wc -l)

--- a/docs/contributing/tests.md
+++ b/docs/contributing/tests.md
@@ -28,6 +28,13 @@ In particular, running only the tests which do not use fuzzing or the PHP API ta
 docker compose exec python-api python -m pytest tests -m "not php_api and not slow"
 ```
 
+Some tests require elastic search indices to be constructed.
+These indices can be constructed by the PHP API container on startup,
+but by default this is turned off because it can be a time consuming process.
+If you see skipped tests indicating errors with elasticsearch, it is likely that
+indices still need to be created. To do so, set the `INDEX_ES_DURING_STARTUP` variable
+in the `docker/php/.env` file to `true` before starting the container.
+
 ## Writing Tests
 
 We use the ubiquitous [Pytest](https://docs.pytest.org) framework when writing tests.


### PR DESCRIPTION
I noticed that the ES indices were not created during CI and so some of the integration tests were skipped.