### PR TITLE
fix: update docstrings with correct status code

### DIFF
--- a/tests/routers/openml/runs_trace_test.py
+++ b/tests/routers/openml/runs_trace_test.py
@@ -33,7 +33,7 @@ async def test_get_run_trace_success(run_id: int, py_api: httpx.AsyncClient) -> 
 
 @pytest.mark.parametrize("run_id", [24])
 async def test_get_run_trace_no_trace(run_id: int, py_api: httpx.AsyncClient) -> None:
-    """Test that 412 is returned for a run that exists but has no trace."""
+    """Test that 404 is returned for a run that exists but has no trace."""
     response = await py_api.get(f"/run/trace/{run_id}")
     assert response.status_code == HTTPStatus.NOT_FOUND
     body = response.json()
@@ -45,7 +45,7 @@ async def test_get_run_trace_no_trace(run_id: int, py_api: httpx.AsyncClient) ->
 
 @pytest.mark.parametrize("run_id", [999999])
 async def test_get_run_trace_run_not_found(run_id: int, py_api: httpx.AsyncClient) -> None:
-    """Test that 412 is returned when the run does not exist."""
+    """Test that 404 is returned when the run does not exist."""
     response = await py_api.get(f"/run/trace/{run_id}")
     assert response.status_code == HTTPStatus.NOT_FOUND
     body = response.json()


### PR DESCRIPTION
Fixes #332 

- updated the docstrings in tests to reflect the new Python API implementation(`412` to `404`)

# Checklist

Always:
- [x] I have performed a self-review of my own pull request to ensure it contains all relevant information, and the proposed changes are minimal but sufficient to accomplish their task.

Required for code changes:
- [x] Tests pass locally
- [x] I have commented my code in hard-to-understand areas, and provided or updated docstrings as needed
- [x] Changes are already covered under existing tests
