### PR TITLE
Make sure to return groups if loaded but empty

### DIFF
--- a/src/database/users.py
+++ b/src/database/users.py
@@ -136,7 +136,7 @@ class User:
         return None
 
     async def get_groups(self) -> list[UserGroup]:
-        if self._groups:
+        if self._groups is not None:
             return self._groups
 
         if self._database is None:


### PR DESCRIPTION
# Description
meant to be merged with the previous PR but forgot to commit

There currently isn't really a way for a user to have no group, but it's also not specifically prohibited. User groups need to be re-examined anyway because they are effectively not used (other than regular user vs admin).